### PR TITLE
 Molecules.rs Documentation

### DIFF
--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -208,7 +208,7 @@ impl Atom {
     pub fn new(element: Element, capacity: u32) -> Self {
         Self { element, capacity }
     }
-    /// Function to get the element of a particular atom
+    /// Returns the element of a particular atom
     pub fn element(&self) -> Element {
         self.element
     }
@@ -250,15 +250,15 @@ impl Molecule {
 
         Some(output_graph)
     }
-    /// Returns a boolean for this molecule being isomorphic to another molecule
+    /// Return true if self is isomorphic to other
     pub fn is_isomorphic_to(&self, other: &Molecule) -> bool {
         is_isomorphic(&self.graph, &other.graph)
     }
-    /// Returns a boolean for this molecule being isomorphic to some piece of another molecule
+    /// Return true if self is a subgraph of other
     pub fn is_subgraph_of(&self, other: &Molecule) -> bool {
         is_isomorphic_subgraph(&self.graph, &other.graph)
     }
-    /// Returns the set of all subgraphs of this molecule as an iterable data structure
+    /// Return set of all subgraphs of self as an iterable data structure
     pub fn enumerate_subgraphs(&self) -> impl Iterator<Item = NodeSet> {
         let mut solutions = HashSet::new();
         let remainder = BTreeSet::from_iter(self.graph.node_indices());
@@ -270,7 +270,7 @@ impl Molecule {
         );
         solutions.into_iter().filter(|s| !s.is_empty())
     }
-    /// Returns a boolean value for if this molecule is formed in a valid way
+    /// Return true if self is formed in a valid way
     ///
     /// In particular, a molecule is considered to be malformed if it contains
     /// multiple edges between the same source and destinations, or if there
@@ -320,9 +320,8 @@ impl Molecule {
             solutions.insert(subset);
         }
     }
-    /// Returns an iterator for a molecule which contains all duplicate and
-    /// non-overlapping pairs of isomorphic subgraphs.  Each of these subgraphs
-    /// is represented as a bitset.
+    /// Return an iterator of bitsets from self containing all duplicate and
+    /// non-overlapping pairs of isomorphic subgraphs
     pub fn matches(&self) -> impl Iterator<Item = (BitSet, BitSet)> {
         let mut matches = BTreeSet::new();
         for subgraph in self.enumerate_subgraphs() {
@@ -351,8 +350,8 @@ impl Molecule {
         }
         matches.into_iter()
     }
-    /// Function that computes (all possible) ways to partition a molecule
-    /// and returns this as an iterable data structure
+    /// Returns all ways to partition self as an iterable data structure of
+    /// molecule pairs
     pub fn partitions(&self) -> Option<impl Iterator<Item = (Molecule, Molecule)> + '_> {
         let mut solutions = HashSet::new();
         let remaining_edges = self.graph.edge_indices().collect();
@@ -405,7 +404,7 @@ impl Molecule {
     pub fn from_graph(g: MGraph) -> Self {
         Self { graph: g }
     }
-    /// Function that constructs an isolated single bond as a molecule.
+    /// Returns isolated single bond as a molecule.
     pub fn single_bond() -> Self {
         let mut g = Graph::default();
         let u = g.add_node(Atom {
@@ -419,7 +418,7 @@ impl Molecule {
         g.add_edge(u, v, Bond::Single);
         Self { graph: g }
     }
-    /// Function that constructs an isolated double bond as a molecule.
+    /// Returns isolated double bond as a molecule.
     pub fn double_bond() -> Self {
         let mut g = Graph::default();
         let u = g.add_node(Atom {
@@ -433,18 +432,16 @@ impl Molecule {
         g.add_edge(u, v, Bond::Double);
         Self { graph: g }
     }
-    /// Boolean function; Returns true if and only if a molecule is an
-    /// isolated edge, which is a floating bond with no atoms
+    /// Return true if and only if self is a single or double bond
     pub fn is_basic_unit(&self) -> bool {
             self.is_isomorphic_to(&Molecule::single_bond())
             || self.is_isomorphic_to(&Molecule::double_bond())
     }
-    /// Function to get the graph of a molecule
+    /// Return the graph of self as an MGraph
     pub fn graph(&self) -> &MGraph {
         &self.graph
     }
-    /// Function to build and return a non-ambiguous string representation 
-    /// of a molecule
+    /// Return a non-ambiguous string representation of self
     pub fn info(&self) -> String {
         let mut info = String::new();
         let g = self.graph();
@@ -473,8 +470,8 @@ impl Molecule {
 
 // Performance improvement would likely happen if we switch from vf2 to vf3;
 // this is a TODO when there is more time
-/// Compute isomorphic subgraphs, currently uses vf2 as the method for doing so;
-/// Isomorphic subgraphs are returned as a vector
+/// Return vector containing isomorphic subgraphs if pattern is isomorphic to
+/// a subgraph of target
 pub fn isomorphic_subgraphs_of(pattern: &MGraph, target: &MSubgraph) -> Vec<Vec<NodeIndex<Index>>> {
     if let Some(iter) =
         subgraph_isomorphisms_iter(&pattern, &target, &mut |n0, n1| n1 == n0, &mut |e0, e1| {
@@ -491,33 +488,6 @@ pub fn isomorphic_subgraphs_of(pattern: &MGraph, target: &MSubgraph) -> Vec<Vec<
 mod tests {
     #![allow(unused_imports)]
     use super::*;
-
-    #[test]
-    fn join_carbonyl_hydroxyl() {
-        let c = Molecule::carbonyl();
-        let h = Molecule::hydroxyl();
-        let j = c
-            .join(&h, [(NodeIndex::new(0), NodeIndex::new(0))])
-            .unwrap();
-
-        let mut g = Graph::default();
-        let u = g.add_node(Atom {
-            capacity: 4,
-            element: Element::Carbon,
-        });
-        let v = g.add_node(Atom {
-            capacity: 2,
-            element: Element::Oxygen,
-        });
-        let w = g.add_node(Atom {
-            capacity: 2,
-            element: Element::Oxygen,
-        });
-        g.add_edge(u, v, Bond::Single);
-        g.add_edge(u, w, Bond::Double);
-
-        assert!(j.is_isomorphic_to(&Molecule { graph: g }));
-    }
 
     #[test]
     fn element_to_string() {


### PR DESCRIPTION
Wrote documentation for public functions in the 'molecules.rs' file; Removed 'carbonyl' and 'hydroxl' functions as they are no longer necessary, adjusted the 'matches' function to no longer use 'carbonyl' and 'hydroxl'.