### PR TITLE
Modified the logic of parse_molfile_str to always exclude hydrogen

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -233,6 +233,7 @@ jobs:
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
+        env:
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
This change makes our parsing consistent with `assembly_go`

I've decided to enforce this consistency as comparing to `RDKit` would require use to develop a huge amount of infrastructure that we don't need (as we don't track chirality, charge etc)