### PR TITLE
Temporary fix for ground truth

### DIFF
--- a/data/gdb13_1201/ma-index.csv
+++ b/data/gdb13_1201/ma-index.csv
@@ -646,7 +646,7 @@ file_name,assembly_idx
 0645.mol,6
 0646.mol,6
 0647.mol,6
-0648.mol,6
+0648.mol,5
 0649.mol,7
 0650.mol,5
 0651.mol,6
@@ -667,7 +667,7 @@ file_name,assembly_idx
 0666.mol,6
 0667.mol,6
 0668.mol,6
-0669.mol,5
+0669.mol,4
 0670.mol,5
 0671.mol,6
 0672.mol,6
@@ -681,7 +681,7 @@ file_name,assembly_idx
 0680.mol,6
 0681.mol,6
 0682.mol,6
-0683.mol,6
+0683.mol,5
 0684.mol,5
 0685.mol,7
 0686.mol,7
@@ -946,7 +946,7 @@ file_name,assembly_idx
 0945.mol,6
 0946.mol,5
 0947.mol,7
-0948.mol,7
+0948.mol,6
 0949.mol,6
 0950.mol,6
 0951.mol,6
@@ -978,7 +978,7 @@ file_name,assembly_idx
 0977.mol,6
 0978.mol,7
 0979.mol,6
-0980.mol,7
+0980.mol,6
 0981.mol,6
 0982.mol,6
 0983.mol,7
@@ -1085,7 +1085,7 @@ file_name,assembly_idx
 1084.mol,6
 1085.mol,5
 1086.mol,8
-1087.mol,7
+1087.mol,6
 1088.mol,6
 1089.mol,8
 1090.mol,7
@@ -1190,7 +1190,7 @@ file_name,assembly_idx
 1189.mol,6
 1190.mol,7
 1191.mol,7
-1192.mol,7
+1192.mol,6
 1193.mol,8
 1194.mol,6
 1195.mol,6

--- a/data/gdb17_200/ma-index.csv
+++ b/data/gdb17_200/ma-index.csv
@@ -87,7 +87,7 @@ file_name,assembly_idx
 086.mol,10
 087.mol,8
 088.mol,8
-089.mol,8
+089.mol,7
 090.mol,8
 091.mol,10
 092.mol,10
@@ -124,7 +124,7 @@ file_name,assembly_idx
 123.mol,13
 124.mol,10
 125.mol,8
-126.mol,11
+126.mol,10
 127.mol,11
 128.mol,8
 129.mol,11
@@ -170,7 +170,7 @@ file_name,assembly_idx
 169.mol,13
 170.mol,9
 171.mol,9
-172.mol,11
+172.mol,10
 173.mol,12
 174.mol,9
 175.mol,12
@@ -192,7 +192,7 @@ file_name,assembly_idx
 191.mol,12
 192.mol,11
 193.mol,14
-194.mol,13
+194.mol,12
 195.mol,11
 196.mol,14
 197.mol,9


### PR DESCRIPTION
AssemblyGo is still not yielding the correct answers. I'm trying to run this down. Here's a temporary fix with the corrected ground truth. 