### PR TITLE
Merge modularize and more enumeration

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -40,29 +40,28 @@ pub fn reference_datasets(c: &mut Criterion) {
                 parse_molfile_str(
                     &fs::read_to_string(name.clone())
                         .expect(&format!("Could not read file {name:?}")),
-                ).expect(&format!("Failed to parse {name:?}")),
+                )
+                .expect(&format!("Failed to parse {name:?}")),
             );
         }
 
         // For each of the bounds options, run the benchmark over all molecules
         // in this dataset.
         for (bound, bound_str) in zip(&bounds, &bound_strs) {
-            group.bench_with_input(
-                BenchmarkId::new(*dataset, &bound_str),
-                bound,
-                |b, bound| {
-                    b.iter(|| {
-                        for mol in &mol_list {
-                            index_search(
-                                &mol,
-                                EnumerateMode::GrowErode,
-                                CanonizeMode::Nauty,
-                                ParallelMode::Always,
-                                KernelMode::None,
-                                &bound,
-                                false);
-                        }
-                    });
+            group.bench_with_input(BenchmarkId::new(*dataset, &bound_str), bound, |b, bound| {
+                b.iter(|| {
+                    for mol in &mol_list {
+                        index_search(
+                            &mol,
+                            EnumerateMode::GrowErode,
+                            CanonizeMode::Nauty,
+                            ParallelMode::Always,
+                            KernelMode::None,
+                            &bound,
+                            false,
+                        );
+                    }
+                });
             });
         }
     }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -7,6 +7,7 @@ use assembly_theory::{
     bounds::Bound,
     canonize::CanonizeMode,
     enumerate::EnumerateMode,
+    kernels::KernelMode,
     loader::parse_molfile_str,
     molecule::Molecule,
 };
@@ -57,7 +58,9 @@ pub fn reference_datasets(c: &mut Criterion) {
                                 EnumerateMode::GrowErode,
                                 CanonizeMode::Nauty,
                                 ParallelMode::Always,
-                                &bound);
+                                KernelMode::None,
+                                &bound,
+                                false);
                         }
                     });
             });

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -5,7 +5,8 @@ use std::iter::zip;
 use std::path::Path;
 
 use assembly_theory::{
-    assembly::{index_search, Bound},
+    assembly::index_search,
+    bounds::Bound,
     loader,
     molecule::Molecule,
 };
@@ -19,12 +20,8 @@ pub fn reference_datasets(c: &mut Criterion) {
     let bounds = [
         vec![],
         vec![Bound::Log],
-        vec![Bound::IntChain],
-        vec![
-            Bound::IntChain,
-            Bound::VecChainSimple,
-            Bound::VecChainSmallFrags,
-        ],
+        vec![Bound::Int],
+        vec![Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
     ];
     let bound_strs = ["naive", "logbound", "intbound", "allbounds"];
 

--- a/data/stress/ma-index.csv
+++ b/data/stress/ma-index.csv
@@ -1,0 +1,4 @@
+file_name,assembly_idx
+phospholipid2.mol,21
+phospholipid.mol,22
+space_PAH.mol,8

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -314,8 +314,8 @@ fn recurse_index_search_parallel(
 /// - `u32`: The molecule's assembly index.
 /// - `u32`: The molecule's count of non-overlapping isomorphic subgraph pairs.
 /// - `usize`: The total number of assembly states searched, where an assembly
-/// state is a collection of fragments; note that some states may be searched
-/// and thus counted by this value multiple times.
+///     state is a collection of fragments; note that some states may be
+///     searched and thus counted by this value multiple times.
 ///
 /// # Example
 /// ```

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -24,6 +24,7 @@ use std::sync::{
 };
 
 use bit_set::BitSet;
+use clap::ValueEnum;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
@@ -37,6 +38,30 @@ use crate::{
     molecule::Molecule,
     utils::connected_components_under_edges,
 };
+
+/// Parallelization strategy for the search phase.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum ParallelMode {
+    /// No parallelism.
+    None,
+    /// Create a task pool form the recursion's first level only.
+    DepthOne,
+    /// Spawn a new thread at every recursive call.
+    Always,
+}
+
+/// Graph kernelization strategy when searching using the clique reduction.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum KernelMode {
+    /// No kernelization.
+    None,
+    /// Only kernelize the original molecule.
+    Once,
+    /// Kernelize the original molecule and the recursion's first level only.
+    DepthOne,
+    /// Perform kernelization at every recursive step.
+    Always,
+}
 
 static PARALLEL_MATCH_SIZE_THRESHOLD: usize = 100;
 

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -314,8 +314,8 @@ fn recurse_index_search_parallel(
 /// - `u32`: The molecule's assembly index.
 /// - `u32`: The molecule's count of non-overlapping isomorphic subgraph pairs.
 /// - `usize`: The total number of assembly states searched, where an assembly
-///     state is a collection of fragments; note that some states may be
-///     searched and thus counted by this value multiple times.
+///   state is a collection of fragments; note that some states may be searched
+///   and thus counted by this value multiple times.
 ///
 /// # Example
 /// ```

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,0 +1,180 @@
+use bit_set::BitSet;
+
+use crate::molecule::{Bond, Element, Molecule};
+
+/// Bounding strategies for the search phase of assembly index calcluation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Bound {
+    /// Trivial bound of log_2(# remaining bonds/edges).
+    Log,
+    /// Bound using the length of the shortest integer addition chain defined
+    /// using fragment sizes.
+    Int,
+    /// Bound using the length of the shortest vector addition chain defined
+    /// using fragments' number and types of edges.
+    VecSimple,
+    /// Bound using the length of the shortest vector addition chain defined
+    /// using information about the molecule's number of fragments of size 2.
+    VecSmallFrags,
+    /// TODO
+    CoverSort,
+    /// TODO
+    CoverNoSort,
+    /// TODO
+    CliqueBudget,
+}
+
+/// Edge information used in vector addition chain bounds.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct EdgeType {
+    bond: Bond,
+    ends: (Element, Element),
+}
+
+/// TODO
+pub fn log_bound(fragments: &[BitSet]) -> usize {
+    let mut size = 0;
+    for f in fragments {
+        size += f.len();
+    }
+
+    size - (size as f32).log2().ceil() as usize
+}
+
+/// TODO
+pub fn int_bound(fragments: &[BitSet], m: usize) -> usize {
+    let mut max_s: usize = 0;
+    let mut frag_sizes: Vec<usize> = Vec::new();
+
+    for f in fragments {
+        frag_sizes.push(f.len());
+    }
+
+    let size_sum: usize = frag_sizes.iter().sum();
+
+    // Test for all sizes m of largest removed duplicate
+    for max in 2..m + 1 {
+        let log = (max as f32).log2().ceil();
+        let mut aux_sum: usize = 0;
+
+        for len in &frag_sizes {
+            aux_sum += (len / max) + (len % max != 0) as usize
+        }
+
+        max_s = max_s.max(size_sum - log as usize - aux_sum);
+    }
+
+    max_s
+}
+
+/// TODO
+// Count number of unique edges in a fragment
+// Helper function for vector bounds
+fn unique_edges(fragment: &BitSet, mol: &Molecule) -> Vec<EdgeType> {
+    let g = mol.graph();
+    let mut nodes: Vec<Element> = Vec::new();
+    for v in g.node_weights() {
+        nodes.push(v.element());
+    }
+    let edges: Vec<petgraph::prelude::EdgeIndex> = g.edge_indices().collect();
+    let weights: Vec<Bond> = g.edge_weights().copied().collect();
+
+    // types will hold an element for every unique edge type in fragment
+    let mut types: Vec<EdgeType> = Vec::new();
+    for idx in fragment.iter() {
+        let bond = weights[idx];
+        let e = edges[idx];
+
+        let (e1, e2) = g.edge_endpoints(e).expect("bad");
+        let e1 = nodes[e1.index()];
+        let e2 = nodes[e2.index()];
+        let ends = if e1 < e2 { (e1, e2) } else { (e2, e1) };
+
+        let edge_type = EdgeType { bond, ends };
+
+        if types.contains(&edge_type) {
+            continue;
+        } else {
+            types.push(edge_type);
+        }
+    }
+
+    types
+}
+
+/// TODO
+pub fn vec_simple_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> usize {
+    // Calculate s (total number of edges)
+    // Calculate z (number of unique edges)
+    let mut s = 0;
+    for f in fragments {
+        s += f.len();
+    }
+
+    let mut union_set = BitSet::new();
+    for f in fragments {
+        union_set.union_with(f);
+    }
+    let z = unique_edges(&union_set, mol).len();
+
+    (s - z) - ((s - z) as f32 / m as f32).ceil() as usize
+}
+
+/// TODO
+pub fn vec_small_frags_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> usize {
+    let mut size_two_fragments: Vec<BitSet> = Vec::new();
+    let mut large_fragments: Vec<BitSet> = fragments.to_owned();
+    let mut indices_to_remove: Vec<usize> = Vec::new();
+
+    // Find and remove fragments of size 2
+    for (i, frag) in fragments.iter().enumerate() {
+        if frag.len() == 2 {
+            indices_to_remove.push(i);
+        }
+    }
+    for &index in indices_to_remove.iter().rev() {
+        let removed_bitset = large_fragments.remove(index);
+        size_two_fragments.push(removed_bitset);
+    }
+
+    // Compute z = num unique edges of large_fragments NOT also in size_two_fragments
+    let mut fragments_union = BitSet::new();
+    let mut size_two_fragments_union = BitSet::new();
+    for f in fragments {
+        fragments_union.union_with(f);
+    }
+    for f in size_two_fragments.iter() {
+        size_two_fragments_union.union_with(f);
+    }
+    let z = unique_edges(&fragments_union, mol).len()
+        - unique_edges(&size_two_fragments_union, mol).len();
+
+    // Compute s = total number of edges in fragments
+    // Compute sl = total number of edges in large fragments
+    let mut s = 0;
+    let mut sl = 0;
+    for f in fragments {
+        s += f.len();
+    }
+    for f in large_fragments {
+        sl += f.len();
+    }
+
+    // Find number of unique size two fragments
+    let mut size_two_types: Vec<(EdgeType, EdgeType)> = Vec::new();
+    for f in size_two_fragments.iter() {
+        let mut types = unique_edges(f, mol);
+        types.sort();
+        if types.len() == 1 {
+            size_two_types.push((types[0], types[0]));
+        } else {
+            size_two_types.push((types[0], types[1]));
+        }
+    }
+    size_two_types.sort();
+    size_two_types.dedup();
+
+    s - (z + size_two_types.len() + size_two_fragments.len())
+        - ((sl - z) as f32 / m as f32).ceil() as usize
+}
+

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -39,8 +39,8 @@ pub fn bound_exceeded(
     mol: &Molecule,
     fragments: &[BitSet],
     ix: usize,
-    largest_remove: usize,
     best: usize,
+    largest_remove: usize,
     bounds: &[Bound],
 ) -> bool {
     for bound_type in bounds {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,3 +1,5 @@
+//! TODO
+
 use bit_set::BitSet;
 use clap::ValueEnum;
 
@@ -30,6 +32,36 @@ pub enum Bound {
 struct EdgeType {
     bond: Bond,
     ends: (Element, Element),
+}
+
+/// TODO 
+pub fn bound_exceeded(
+    mol: &Molecule,
+    fragments: &[BitSet],
+    ix: usize,
+    largest_remove: usize,
+    best: usize,
+    bounds: &[Bound],
+) -> bool {
+    for bound_type in bounds {
+        let exceeds = match bound_type {
+            Bound::Log =>
+                ix - log_bound(fragments) >= best,
+            Bound::Int =>
+                ix - int_bound(fragments, largest_remove) >= best,
+            Bound::VecSimple =>
+                ix - vec_simple_bound(fragments, largest_remove, mol) >= best,
+            Bound::VecSmallFrags =>
+                ix - vec_small_frags_bound(fragments, largest_remove, mol) >= best,
+            _ => {
+                panic!("One of the chosen bounds is not implemented yet!")
+            }
+        };
+        if exceeds {
+            return true;
+        }
+    }
+    false
 }
 
 /// TODO

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,9 +1,10 @@
 use bit_set::BitSet;
+use clap::ValueEnum;
 
 use crate::molecule::{Bond, Element, Molecule};
 
 /// Bounding strategies for the search phase of assembly index calcluation.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum Bound {
     /// Trivial bound of log_2(# remaining bonds/edges).
     Log,

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -34,7 +34,7 @@ struct EdgeType {
     ends: (Element, Element),
 }
 
-/// TODO 
+/// TODO
 pub fn bound_exceeded(
     mol: &Molecule,
     fragments: &[BitSet],
@@ -45,14 +45,12 @@ pub fn bound_exceeded(
 ) -> bool {
     for bound_type in bounds {
         let exceeds = match bound_type {
-            Bound::Log =>
-                ix - log_bound(fragments) >= best,
-            Bound::Int =>
-                ix - int_bound(fragments, largest_remove) >= best,
-            Bound::VecSimple =>
-                ix - vec_simple_bound(fragments, largest_remove, mol) >= best,
-            Bound::VecSmallFrags =>
-                ix - vec_small_frags_bound(fragments, largest_remove, mol) >= best,
+            Bound::Log => ix - log_bound(fragments) >= best,
+            Bound::Int => ix - int_bound(fragments, largest_remove) >= best,
+            Bound::VecSimple => ix - vec_simple_bound(fragments, largest_remove, mol) >= best,
+            Bound::VecSmallFrags => {
+                ix - vec_small_frags_bound(fragments, largest_remove, mol) >= best
+            }
             _ => {
                 panic!("One of the chosen bounds is not implemented yet!")
             }
@@ -210,4 +208,3 @@ pub fn vec_small_frags_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> 
     s - (z + size_two_types.len() + size_two_fragments.len())
         - ((sl - z) as f32 / m as f32).ceil() as usize
 }
-

--- a/src/canonize.rs
+++ b/src/canonize.rs
@@ -1,0 +1,77 @@
+//! Create canonical labelings for molecular graphs.
+
+use std::{
+    collections::HashMap,
+};
+
+use bit_set::BitSet;
+use clap::ValueEnum;
+use graph_canon::CanonLabeling;
+use petgraph::{
+    graph::{EdgeIndex, Graph, NodeIndex},
+    Undirected,
+};
+
+use crate::{
+    molecule::{AtomOrBond, Index, Molecule},
+};
+
+/// Algorithm for graph canonization.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum CanonizeMode {
+    /// Use the Nauty algorithm of McKay & Piperno (2014).
+    Nauty,
+    /// Use the algorithm of Faulon et al. (2004).
+    Faulon,
+    /// Use a fast tree canonization algorithm if applicable; else use Nauty.
+    TreeNauty,
+    /// Use a fast tree canonization algorithm if applicable; else use Faulon.
+    TreeFaulon,
+}
+
+/// Obtain a canonical labeling of the specified `subgraph` using the
+/// algorithm specified by `mode`.
+// TODO: Should return a Box<dyn Hash> to flexibly extend over different
+// canonization algorithms.
+pub fn canonize(mol: &Molecule, subgraph: &BitSet, mode: CanonizeMode)
+    -> CanonLabeling<AtomOrBond> {
+    match mode {
+        CanonizeMode::Nauty => {
+            let cgraph = subgraph_to_cgraph(mol, subgraph);
+            CanonLabeling::new(&cgraph)
+        }
+        _ => {
+            panic!("The chosen --canonize mode is not implemented yet!")
+        }
+    }
+}
+
+/// A graph representation interpretable by Nauty.
+type CGraph = Graph<AtomOrBond, (), Undirected, Index>;
+
+/// Convert the specified `subgraph` to the format expected by Nauty.
+fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
+    let mut h = CGraph::with_capacity(subgraph.len(), 2 * subgraph.len());
+    let mut vtx_map = HashMap::<NodeIndex, NodeIndex>::new();
+    for e in subgraph {
+        let eix = EdgeIndex::new(e);
+        let (src, dst) = mol.graph().edge_endpoints(eix).unwrap();
+        let src_w = mol.graph().node_weight(src).unwrap();
+        let dst_w = mol.graph().node_weight(dst).unwrap();
+        let e_w = mol.graph().edge_weight(eix).unwrap();
+
+        let h_enode = h.add_node(AtomOrBond::Bond(*e_w));
+
+        let h_src = vtx_map
+            .entry(src)
+            .or_insert(h.add_node(AtomOrBond::Atom(*src_w)));
+        h.add_edge(*h_src, h_enode, ());
+
+        let h_dst = vtx_map
+            .entry(dst)
+            .or_insert(h.add_node(AtomOrBond::Atom(*dst_w)));
+        h.add_edge(*h_dst, h_enode, ());
+    }
+    h
+}
+

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -25,10 +25,9 @@ pub enum EnumerateMode {
 
 /// Return an interator over all connected, non-induced subgraphs of the
 /// molecular graph `mol` using the algorithm specified by `mode`.
-pub fn enumerate_subgraphs(mol: &Molecule, mode: EnumerateMode)
-    -> impl Iterator<Item = BitSet> {
+pub fn enumerate_subgraphs(mol: &Molecule, mode: EnumerateMode) -> impl Iterator<Item = BitSet> {
     match mode {
-        EnumerateMode::GrowErode => grow_erode(&mol).into_iter(),
+        EnumerateMode::GrowErode => grow_erode(mol).into_iter(),
         _ => {
             panic!("The chosen --enumerate mode is not implemented yet!");
         }
@@ -46,11 +45,7 @@ fn grow_erode(mol: &Molecule) -> HashSet<BitSet> {
 
     // The remainder is all edges not in the current subset; initially, this is
     // everything.
-    let remainder = BitSet::from_iter(mol
-        .graph()
-        .edge_indices()
-        .map(|ix| ix.index())
-    );
+    let remainder = BitSet::from_iter(mol.graph().edge_indices().map(|ix| ix.index()));
 
     // Set up a set of subgraphs enumerated so far.
     let mut subgraphs = HashSet::new();
@@ -65,7 +60,7 @@ fn grow_erode_recurse(
     mut subset: BitSet,
     mut subsetplus: BitSet,
     mut remainder: BitSet,
-    subgraphs: &mut HashSet<BitSet>
+    subgraphs: &mut HashSet<BitSet>,
 ) {
     // Get the next edge from the current subset's boundary or, if the subset
     // is empty, from the remainder.
@@ -83,7 +78,8 @@ fn grow_erode_recurse(
             subset.clone(),
             subsetplus.clone(),
             remainder.clone(),
-            subgraphs);
+            subgraphs,
+        );
 
         // The other recursive branch will add the candidate edge to the
         // current subset and update the boundary accordingly. However, since
@@ -99,21 +95,15 @@ fn grow_erode_recurse(
                 .graph()
                 .edge_endpoints(EdgeIndex::new(e))
                 .expect("malformed input");
-            subsetplus.extend(mol
-                .graph()
-                .neighbors(src)
-                .filter_map(|n| mol
-                    .graph()
-                    .find_edge(src, n)
-                    .map(|ix| ix.index())),
+            subsetplus.extend(
+                mol.graph()
+                    .neighbors(src)
+                    .filter_map(|n| mol.graph().find_edge(src, n).map(|ix| ix.index())),
             );
-            subsetplus.extend(mol
-                .graph()
-                .neighbors(dst)
-                .filter_map(|n| mol
-                    .graph()
-                    .find_edge(dst, n)
-                    .map(|ix| ix.index())),
+            subsetplus.extend(
+                mol.graph()
+                    .neighbors(dst)
+                    .filter_map(|n| mol.graph().find_edge(dst, n).map(|ix| ix.index())),
             );
 
             // Recurse.
@@ -125,4 +115,3 @@ fn grow_erode_recurse(
         subgraphs.insert(subset);
     }
 }
-

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -1,0 +1,128 @@
+//! Enumerate connected, non-induced subgraphs of a molecular graph.
+
+use std::collections::HashSet;
+
+use bit_set::BitSet;
+use clap::ValueEnum;
+use petgraph::graph::EdgeIndex;
+
+use crate::molecule::Molecule;
+
+/// Strategy for enumerating connected, non-induced subgraphs.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum EnumerateMode {
+    /// Grow connected subgraphs from each edge using BFS.
+    Bfs,
+    /// Like Bfs, but at each level of the BFS, prune any subgraphs that do not
+    /// have isomorphic components since these will not be useful later.
+    BfsPrune,
+    /// From a subgraph, choose an edge from its boundary and recursively grow
+    /// it by adding this edge or erode its remainder by discarding the edge.
+    GrowErode,
+    /// An iterative (memory-efficient) implementation of GrowErode.
+    GrowErodeIterative,
+}
+
+/// Return an interator over all connected, non-induced subgraphs of the
+/// molecular graph `mol` using the algorithm specified by `mode`.
+pub fn enumerate_subgraphs(mol: &Molecule, mode: EnumerateMode)
+    -> impl Iterator<Item = BitSet> {
+    match mode {
+        EnumerateMode::GrowErode => grow_erode(&mol).into_iter(),
+        _ => {
+            panic!("The chosen --enumerate mode is not implemented yet!");
+        }
+    }
+}
+
+/// Enumerate connected, non-induced subgraphs with at most |E|/2 edges; at
+/// each recursive step, choose one edge from the current subgraph's boundary
+/// and either add it to the subgraph or discard it from the remainder.
+fn grow_erode(mol: &Molecule) -> HashSet<BitSet> {
+    // Initialize the current subset of edges and its union with its edge
+    // boundary (in this algorithm, "subsetplus") as empty.
+    let subset = BitSet::new();
+    let subsetplus = BitSet::new();
+
+    // The remainder is all edges not in the current subset; initially, this is
+    // everything.
+    let remainder = BitSet::from_iter(mol
+        .graph()
+        .edge_indices()
+        .map(|ix| ix.index())
+    );
+
+    // Set up a set of subgraphs enumerated so far.
+    let mut subgraphs = HashSet::new();
+
+    // Recurse, and ultimately return the final set of enumerated subgraphs.
+    grow_erode_recurse(mol, subset, subsetplus, remainder, &mut subgraphs);
+    subgraphs
+}
+
+fn grow_erode_recurse(
+    mol: &Molecule,
+    mut subset: BitSet,
+    mut subsetplus: BitSet,
+    mut remainder: BitSet,
+    subgraphs: &mut HashSet<BitSet>
+) {
+    // Get the next edge from the current subset's boundary or, if the subset
+    // is empty, from the remainder.
+    let candidate = if subset.is_empty() {
+        remainder.iter().next()
+    } else {
+        remainder.intersection(&subsetplus).next()
+    };
+
+    if let Some(e) = candidate {
+        // In the first recursive branch, discard the candidate edge entirely.
+        remainder.remove(e);
+        grow_erode_recurse(
+            mol,
+            subset.clone(),
+            subsetplus.clone(),
+            remainder.clone(),
+            subgraphs);
+
+        // The other recursive branch will add the candidate edge to the
+        // current subset and update the boundary accordingly. However, since
+        // we ultimately only care about connected, non-induced subgraphs that
+        // may be part of a non-overlapping isomorphic pair, we need not
+        // recurse if adding the edge exceeds |E|/2 edges.
+        if subset.len() < mol.graph().edge_count() / 2 {
+            // Add the candidate edge to the current subset.
+            subset.insert(e);
+
+            // Grow the boundary to include edges incident to the candidate.
+            let (src, dst) = mol
+                .graph()
+                .edge_endpoints(EdgeIndex::new(e))
+                .expect("malformed input");
+            subsetplus.extend(mol
+                .graph()
+                .neighbors(src)
+                .filter_map(|n| mol
+                    .graph()
+                    .find_edge(src, n)
+                    .map(|ix| ix.index())),
+            );
+            subsetplus.extend(mol
+                .graph()
+                .neighbors(dst)
+                .filter_map(|n| mol
+                    .graph()
+                    .find_edge(dst, n)
+                    .map(|ix| ix.index())),
+            );
+
+            // Recurse.
+            grow_erode_recurse(mol, subset, subsetplus, remainder, subgraphs);
+        }
+    } else if subset.len() > 1 {
+        // When all candidate edges have been exhausted, add this subset as a
+        // new subgraph if it is nonempty.
+        subgraphs.insert(subset);
+    }
+}
+

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -1,0 +1,19 @@
+//! Kernelize molecular graphs to improve top-down search efficiency.
+//!
+//! TODO: Longer explanation of what that means.
+
+use clap::ValueEnum;
+
+/// Graph kernelization strategy when searching using the clique reduction.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum KernelMode {
+    /// No kernelization.
+    None,
+    /// Only kernelize the original molecule.
+    Once,
+    /// Kernelize the original molecule and the recursion's first level only.
+    DepthOne,
+    /// Perform kernelization at every recursive step.
+    Always,
+}
+

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -16,4 +16,3 @@ pub enum KernelMode {
     /// Perform kernelization at every recursive step.
     Always,
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,12 @@ pub mod assembly;
 // Bounding strategies for the search phase.
 pub mod bounds;
 
+// Algorithms for enumerating connected subgraphs of a molecular graph.
+pub mod enumerate;
+
+// Molecule graph canonization algorithms.
+pub mod canonize;
+
 // Utility functions
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ pub mod loader;
 // The hard bit: compute assembly index
 pub mod assembly;
 
+// Bounding strategies for the search phase.
+pub mod bounds;
+
 // Utility functions
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ pub mod enumerate;
 // Molecule graph canonization algorithms.
 pub mod canonize;
 
+// Graph kernelization algorithms.
+pub mod kernels;
+
 // Utility functions
 mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,7 @@ use std::{fs, path::PathBuf};
 
 use anyhow::{bail, Context, Result};
 use assembly_theory::{
-    assembly::{
-        assembly_depth,
-        index_search,
-        ParallelMode,
-    },
+    assembly::{assembly_depth, index_search, ParallelMode},
     bounds::Bound,
     canonize::CanonizeMode,
     enumerate::EnumerateMode,
@@ -77,10 +73,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Load the .mol file as a molecule::Molecule.
-    let molfile = fs::read_to_string(&cli.molpath)
-        .context("Cannot read input file.")?;
-    let mol = parse_molfile_str(&molfile)
-        .context("Cannot parse molfile.")?;
+    let molfile = fs::read_to_string(&cli.molpath).context("Cannot read input file.")?;
+    let mol = parse_molfile_str(&molfile).context("Cannot parse molfile.")?;
     if mol.is_malformed() {
         bail!("Bad input! Molecule has self-loops or multi-edges.")
     }
@@ -100,18 +94,15 @@ fn main() -> Result<()> {
     // Handle bounding strategy CLI arguments.
     let boundlist: &[Bound] = match cli.boundsgroup {
         // By default, use a combination of the integer and vector bounds.
-        None => &[
-            Bound::Int,
-            Bound::VecSimple,
-            Bound::VecSmallFrags,
-        ],
+        None => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
         // If --no-bounds is set, do not use any bounds.
         Some(BoundsGroup {
             no_bounds: true, ..
         }) => &[],
         // Otherwise, use the bounds that were specified.
         Some(BoundsGroup {
-            no_bounds: false, bounds,
+            no_bounds: false,
+            bounds,
         }) => &bounds.clone(),
     };
 
@@ -123,7 +114,8 @@ fn main() -> Result<()> {
         cli.parallel,
         cli.kernel,
         boundlist,
-        cli.memoize);
+        cli.memoize,
+    );
 
     // Print final output, depending on --verbose.
     if cli.verbose {

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, dup_pairs, search_size) = index_search(
+    let (index, num_matches, states_searched) = index_search(
         &mol,
         cli.enumerate,
         cli.canonize,
@@ -128,8 +128,8 @@ fn main() -> Result<()> {
     // Print final output, depending on --verbose.
     if cli.verbose {
         println!("Assembly Index: {index}");
-        println!("Non-Overlapping Isomorphic Subgraph Pairs: {dup_pairs}");
-        println!("Search Space Size: {search_size}");
+        println!("Non-Overlapping Isomorphic Subgraph Pairs: {num_matches}");
+        println!("Assembly States Searched: {states_searched}");
     } else {
         println!("{index}");
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,28 +101,7 @@ struct BoundsGroup {
 
     /// Apply the specified bounding strategies during the search phase.
     #[arg(long, num_args = 1..)]
-    bounds: Vec<BoundOption>,
-}
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum BoundOption {
-    /// Trivial bound of log_2(# remaining bonds/edges).
-    Log,
-    /// Bound using the length of the shortest integer addition chain defined
-    /// using fragment sizes.
-    Int,
-    /// Bound using the length of the shortest vector addition chain defined
-    /// using fragments' number and types of edges.
-    VecSimple,
-    /// Bound using the length of the shortest vector addition chain defined
-    /// using information about the molecule's number of fragments of size 2.
-    VecSmallFrags,
-    /// TODO
-    CoverSort,
-    /// TODO
-    CoverNoSort,
-    /// TODO
-    CliqueBudget,
+    bounds: Vec<Bound>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -135,25 +114,6 @@ enum KernelMode {
     DepthOne,
     /// Perform kernelization at every recursive step.
     Always,
-}
-
-/// Convert CLI `BoundOption`s to a list of `bounds::Bound`s.
-fn make_boundlist(bounds: &[BoundOption]) -> Vec<Bound> {
-    let mut boundlist = bounds
-        .iter()
-        .flat_map(|b| match b {
-            BoundOption::Log => vec![Bound::Log],
-            BoundOption::Int => vec![Bound::Int],
-            BoundOption::VecSimple => vec![Bound::VecSimple],
-            BoundOption::VecSmallFrags => vec![Bound::VecSmallFrags],
-            _ => {
-                println!("WARNING: Ignoring bound not implemented yet");
-                vec![]
-            },
-        })
-        .collect::<Vec<_>>();
-    boundlist.dedup();
-    boundlist
 }
 
 fn main() -> Result<()> {
@@ -238,7 +198,7 @@ fn main() -> Result<()> {
         // Otherwise, use the bounds that were specified.
         Some(BoundsGroup {
             no_bounds: false, bounds,
-        }) => &make_boundlist(&bounds),
+        }) => &bounds.clone(),
     };
 
     // Call index calculation with all the various options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,113 +3,243 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
 use assembly_theory::assembly::{index_search, serial_index_search, Bound};
-use assembly_theory::{loader, molecule::Molecule};
+use assembly_theory::loader;
 use clap::{Args, Parser, ValueEnum};
-
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
-enum Bounds {
-    Log,
-    IntChain,
-    VecChain,
-}
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {
-    path: PathBuf,
+    /// Path to .mol file to compute the assembly index for.
+    molpath: PathBuf,
 
-    #[arg(short, long)]
-    /// Print out search space, duplicate subgraphs, and assembly index
+    /// Print molecule graph information, skipping assembly index calculation.
+    #[arg(long)]
+    molinfo: bool,
+
+    /// Print the assembly index, number of non-overlapping isomorphic subgraph
+    /// pairs, and number of fragment structures searched (i.e., the "search
+    /// space"). Note that the search space may be nondeterministic when run
+    /// using parallelism.
+    #[arg(long)]
     verbose: bool,
 
+    /// Strategy for enumerating connected, non-induced subgraphs.
+    #[arg(long, value_enum, default_value_t = EnumerateMode::GrowErode)]
+    enumerate: EnumerateMode,
+
+    /// Algorithm for graph canonization.
+    #[arg(long, value_enum, default_value_t = CanonizeMode::Nauty)]
+    canonize: CanonizeMode,
+
+    /// Parallelization strategy for the search phase.
+    #[arg(long, value_enum, default_value_t = ParallelMode::Always)]
+    parallel: ParallelMode,
+
+    /// Use dynamic programming memoization in the search phase.
+    #[arg(long)]
+    memoize: bool,
+
+    /// Bounding strategies to apply in the search phase.
     #[command(flatten)]
-    boundgroup: Option<BoundGroup>,
+    boundsgroup: Option<BoundsGroup>,
 
-    #[arg(long)]
-    /// Dump out molecule graph
-    molecule_info: bool,
+    /// Strategy for performing graph kernelization during the search phase.
+    #[arg(long, value_enum, default_value_t = KernelMode::None)]
+    kernel: KernelMode,
+}
 
-    #[arg(long)]
-    /// Disable all parallelism
-    serial: bool,
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum EnumerateMode {
+    /// Grow connected subgraphs from each edge using BFS.
+    Bfs,
+    /// Like Bfs, but at each level of the BFS, prune any subgraphs that do not
+    /// have isomorphic components since these will not be useful later.
+    BfsPrune,
+    /// From a subgraph, choose an edge from its frontier and recursively grow
+    /// the subgraph by this edge or erode it by discarding the edge.
+    GrowErode,
+    /// An iterative (memory-efficient) implementation of GrowErode.
+    GrowErodeIterative,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum CanonizeMode {
+    /// Use the Nauty algorithm of McKay & Piperno (2014).
+    Nauty,
+    /// Use the algorithm of Faulon et al. (2004).
+    Faulon,
+    /// Use a fast tree canonization algorithm if applicable; else use Nauty.
+    TreeNauty,
+    /// Use a fast tree canonization algorithm if applicable; else use Faulon.
+    TreeFaulon,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum ParallelMode {
+    /// No parallelism.
+    None,
+    /// Create a task pool form the recursion's first level only.
+    DepthOne,
+    /// Spawn a new thread at every recursive call.
+    Always,
 }
 
 #[derive(Args, Debug)]
 #[group(required = false, multiple = false)]
-struct BoundGroup {
+struct BoundsGroup {
+    /// Do not use any bounding strategy during the search phase.
     #[arg(long)]
-    /// Run branch-and-bound index search with no bounds
     no_bounds: bool,
 
+    /// Apply the specified bounding strategies during the search phase.
     #[arg(long, num_args = 1..)]
-    /// Run branch-and-bound index search with only specified bounds
-    bounds: Vec<Bounds>,
+    bounds: Vec<BoundOption>,
 }
 
-fn make_boundlist(u: &[Bounds]) -> Vec<Bound> {
-    let mut boundlist = u
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum BoundOption {
+    /// The trivial bound of log_2(b), where b is # of remaining bonds.
+    Log,
+    /// TODO
+    Int,
+    /// TODO
+    VecSimple,
+    /// TODO
+    VecSmallFrags,
+    /// TODO
+    CoverSort,
+    /// TODO
+    CoverNoSort,
+    /// TODO
+    CliqueBudget,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+enum KernelMode {
+    /// No kernelization.
+    None,
+    /// Only kernelize the original molecule.
+    Once,
+    /// Kernelize the original molecule and the recursion's first level only.
+    DepthOne,
+    /// Perform kernelization at every recursive step.
+    Always,
+}
+
+/// Convert CLI BoundOptions to a list of assembly::Bounds.
+fn make_boundlist(bounds: &[BoundOption]) -> Vec<Bound> {
+    let mut boundlist = bounds
         .iter()
         .flat_map(|b| match b {
-            Bounds::Log => vec![Bound::Log],
-            Bounds::IntChain => vec![Bound::IntChain],
-            Bounds::VecChain => vec![Bound::VecChainSimple, Bound::VecChainSmallFrags],
+            BoundOption::Log => vec![Bound::Log],
+            BoundOption::Int => vec![Bound::IntChain],
+            BoundOption::VecSimple => vec![Bound::VecChainSimple],
+            BoundOption::VecSmallFrags => vec![Bound::VecChainSmallFrags],
+            _ => {
+                println!("WARNING: Ignoring bound not implemented yet");
+                vec![]
+            },
         })
         .collect::<Vec<_>>();
     boundlist.dedup();
     boundlist
 }
 
-fn index_message(mol: &Molecule, bounds: &[Bound], verbose: bool, serial: bool) -> String {
-    let (index, duplicates, space) = if serial {
-        serial_index_search(mol, bounds)
-    } else {
-        index_search(mol, bounds)
-    };
-    if verbose {
-        let mut message = String::new();
-        message.push_str(&format!("Assembly index: {index}\n"));
-        message.push_str(&format!("Duplicate subgraph pairs: {duplicates}\n"));
-        message.push_str(&format!("Search space: {space}"));
-        message
-    } else {
-        index.to_string()
-    }
-}
-
 fn main() -> Result<()> {
+    // Parse command line arguments.
     let cli = Cli::parse();
-    let molfile = fs::read_to_string(&cli.path).context("Cannot read input file.")?;
-    let molecule = loader::parse_molfile_str(&molfile).context("Cannot parse molfile.")?;
+
+    // Load the .mol file as a molecule::Molecule.
+    let molfile = fs::read_to_string(&cli.molpath)
+        .context("Cannot read input file.")?;
+    let molecule = loader::parse_molfile_str(&molfile)
+        .context("Cannot parse molfile.")?;
     if molecule.is_malformed() {
-        bail!("Bad input! Molecule has self-loops or doubled edges")
+        bail!("Bad input! Molecule has self-loops or multi-edges.")
     }
 
-    if cli.molecule_info {
+    // If --molinfo is set, print molecule graph and exit.
+    if cli.molinfo {
         println!("{}", molecule.info());
         return Ok(());
     }
 
-    let output = match cli.boundgroup {
-        None => index_message(
-            &molecule,
-            &[
-                Bound::IntChain,
-                Bound::VecChainSimple,
-                Bound::VecChainSmallFrags,
-            ],
-            cli.verbose,
-            cli.serial,
-        ),
-        Some(BoundGroup {
-            no_bounds: true, ..
-        }) => index_message(&molecule, &[], cli.verbose, cli.serial),
-        Some(BoundGroup {
-            no_bounds: false,
-            bounds,
-        }) => index_message(&molecule, &make_boundlist(&bounds), cli.verbose, cli.serial),
+    // TODO: Do something about EnumerateModes.
+    match cli.enumerate {
+        EnumerateMode::Bfs => {
+            println!("WARNING: Ignoring EnumerateMode::Bfs; not implemented yet");
+        }
+        EnumerateMode::BfsPrune => {
+            println!("WARNING: Ignoring EnumerateMode::BfsPrune; not implemented yet");
+        }
+        EnumerateMode::GrowErode => {
+            println!("Using recursive grow-erode for subgraph enumeration");
+        }
+        EnumerateMode::GrowErodeIterative => {
+            println!("WARNING: Ignoring EnumerateMode::GrowErodeIterative; not implemented yet");
+        }
+    }
+
+    // TODO: Do something about CanonizeModes.
+    match cli.canonize {
+        CanonizeMode::Nauty => {
+            println!("Using nauty for graph canonization");
+        }
+        CanonizeMode::Faulon => {
+            println!("WARNING: Ignoring CanonizeMode::Faulon; not implemented yet");
+        }
+        CanonizeMode::TreeNauty => {
+            println!("WARNING: Ignoring CanonizeMode::TreeNauty; not implemented yet");
+        }
+        CanonizeMode::TreeFaulon => {
+            println!("WARNING: Ignoring CanonizeMode::TreeFaulon; not implemented yet");
+        }
+    }
+
+    // TODO: Do something about ParallelModes.
+    let parallel = match cli.parallel {
+        ParallelMode::None => false,
+        ParallelMode::DepthOne => {
+            println!("WARNING: Ignoring ParallelMode::DepthOne; not implemented yet");
+            false
+        },
+        ParallelMode::Always => true,
     };
 
-    println!("{output}");
+    // Handle bounding strategy CLI arguments.
+    let boundlist: &[Bound] = match cli.boundsgroup {
+        // By default, use a combination of the integer and vector bounds.
+        None => &[
+            Bound::IntChain,
+            Bound::VecChainSimple,
+            Bound::VecChainSmallFrags,
+        ],
+        // If --no-bounds is set, do not use any bounds.
+        Some(BoundsGroup {
+            no_bounds: true, ..
+        }) => &[],
+        // Otherwise, use the bounds that were specified.
+        Some(BoundsGroup {
+            no_bounds: false, bounds,
+        }) => &make_boundlist(&bounds),
+    };
+
+    // Call index calculation with all the various options.
+    // TODO: Rework with the full list of options.
+    let (index, dup_pairs, search_size) = if parallel {
+        index_search(&molecule, boundlist)
+    } else {
+        serial_index_search(&molecule, boundlist)
+    };
+
+    // Print final output, depending on --verbose.
+    if cli.verbose {
+        println!("Assembly Index: {index}");
+        println!("# Non-Overlapping Isomorphic Subgraph Pairs: {dup_pairs}");
+        println!("Search Space Size: {search_size}");
+    } else {
+        println!("{index}");
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,14 @@ use std::{fs, path::PathBuf};
 use anyhow::{bail, Context, Result};
 use assembly_theory::{
     assembly::{
-        ParallelMode,
-        KernelMode,
         assembly_depth,
         index_search,
+        ParallelMode,
     },
     bounds::Bound,
     canonize::CanonizeMode,
     enumerate::EnumerateMode,
+    kernels::KernelMode,
     loader::parse_molfile_str,
 };
 use clap::{Args, Parser};
@@ -116,8 +116,14 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, dup_pairs, search_size) =
-        index_search(&mol, cli.enumerate, cli.canonize, cli.parallel, boundlist);
+    let (index, dup_pairs, search_size) = index_search(
+        &mol,
+        cli.enumerate,
+        cli.canonize,
+        cli.parallel,
+        cli.kernel,
+        boundlist,
+        cli.memoize);
 
     // Print final output, depending on --verbose.
     if cli.verbose {

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -272,7 +272,7 @@ impl Molecule {
                     .is_some_and(|(src, dst)| src != dst)
         })
     }
-    
+
     /// Return `true` iff this molecule comprises only one bond (of any type).
     pub fn is_basic_unit(&self) -> bool {
         self.graph.edge_count() == 1 && self.graph.node_count() == 2
@@ -316,8 +316,7 @@ impl Molecule {
 
     /// Return an iterator over all ways of partitioning this molecule into two
     /// submolecules.
-    pub fn partitions(&self) ->
-        Option<impl Iterator<Item = (Molecule, Molecule)> + '_> {
+    pub fn partitions(&self) -> Option<impl Iterator<Item = (Molecule, Molecule)> + '_> {
         let mut solutions = HashSet::new();
         let remaining_edges = self.graph.edge_indices().collect();
         self.backtrack(

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use bit_set::BitSet;
+use clap::ValueEnum;
 use graph_canon::CanonLabeling;
 use petgraph::{
     algo::{is_isomorphic, is_isomorphic_subgraph},
@@ -25,6 +26,34 @@ pub(crate) type MGraph = Graph<Atom, Bond, Undirected, Index>;
 type CGraph = Graph<AtomOrBond, (), Undirected, Index>;
 type EdgeSet = BTreeSet<EdgeIndex<Index>>;
 type NodeSet = BTreeSet<NodeIndex<Index>>;
+
+/// Strategy for enumerating connected, non-induced subgraphs.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum EnumerateMode {
+    /// Grow connected subgraphs from each edge using BFS.
+    Bfs,
+    /// Like Bfs, but at each level of the BFS, prune any subgraphs that do not
+    /// have isomorphic components since these will not be useful later.
+    BfsPrune,
+    /// From a subgraph, choose an edge from its frontier and recursively grow
+    /// the subgraph by this edge or erode it by discarding the edge.
+    GrowErode,
+    /// An iterative (memory-efficient) implementation of GrowErode.
+    GrowErodeIterative,
+}
+
+/// Algorithm for graph canonization.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
+pub enum CanonizeMode {
+    /// Use the Nauty algorithm of McKay & Piperno (2014).
+    Nauty,
+    /// Use the algorithm of Faulon et al. (2004).
+    Faulon,
+    /// Use a fast tree canonization algorithm if applicable; else use Nauty.
+    TreeNauty,
+    /// Use a fast tree canonization algorithm if applicable; else use Faulon.
+    TreeFaulon,
+}
 
 macro_rules! periodic_table {
     ( $(($element:ident, $name:literal),)* ) => {

--- a/src/python.rs
+++ b/src/python.rs
@@ -142,8 +142,7 @@ impl FromStr for PyBound {
 
 /// Converts a `HashSet<String>` of bound strings from Python into a
 /// `Vec<PyBound>`, raising an error if any bound string is invalid.
-fn process_bound_strs(bound_strs: HashSet<String>)
-    -> PyResult<Vec<PyBound>> {
+fn process_bound_strs(bound_strs: HashSet<String>) -> PyResult<Vec<PyBound>> {
     bound_strs
         .iter()
         .map(|s| s.parse())
@@ -250,8 +249,7 @@ pub fn _index_search(
         Ok(PyEnumerateMode::Bfs) => EnumerateMode::Bfs,
         Ok(PyEnumerateMode::BfsPrune) => EnumerateMode::BfsPrune,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
-        Ok(PyEnumerateMode::GrowErodeIterative) =>
-            EnumerateMode::GrowErodeIterative,
+        Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")
         }
@@ -293,7 +291,8 @@ pub fn _index_search(
         parallel_mode,
         kernel_mode,
         &boundlist,
-        memoize);
+        memoize,
+    );
 
     Ok(index)
 }
@@ -326,7 +325,7 @@ pub fn _index_search_verbose(
     parallel_str: String,
     kernel_str: String,
     bound_strs: HashSet<String>,
-    memoize: bool
+    memoize: bool,
 ) -> PyResult<HashMap<String, usize>> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol_result = parse_molfile_str(&mol_block);
@@ -340,8 +339,7 @@ pub fn _index_search_verbose(
         Ok(PyEnumerateMode::Bfs) => EnumerateMode::Bfs,
         Ok(PyEnumerateMode::BfsPrune) => EnumerateMode::BfsPrune,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
-        Ok(PyEnumerateMode::GrowErodeIterative) =>
-            EnumerateMode::GrowErodeIterative,
+        Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")
         }
@@ -383,7 +381,8 @@ pub fn _index_search_verbose(
         parallel_mode,
         kernel_mode,
         &boundlist,
-        memoize);
+        memoize,
+    );
 
     // Package results and return.
     let mut data = HashMap::new();

--- a/src/python.rs
+++ b/src/python.rs
@@ -315,7 +315,7 @@ pub fn _index_search(
 ///   - `"index"`: The molecule's assembly index.
 ///   - `"num_matches"`: The molecule's number of non-overlapping isomorphic
 ///   subgraph pairs.
-///   - `"search_size"`: The number of states in the search space.
+///   - `"states_searched"`: The number of assembly states searchede.
 ///
 /// TODO: Add Python example.
 #[pyfunction]
@@ -376,7 +376,7 @@ pub fn _index_search_verbose(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    let (index, num_matches, search_size) = index_search(
+    let (index, num_matches, states_searched) = index_search(
         &mol,
         enumerate_mode,
         canonize_mode,
@@ -389,7 +389,7 @@ pub fn _index_search_verbose(
     let mut data = HashMap::new();
     data.insert("index".to_string(), index as usize);
     data.insert("num_matches".to_string(), num_matches as usize);
-    data.insert("search_size".to_string(), search_size);
+    data.insert("states_searched".to_string(), states_searched);
 
     Ok(data)
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -8,9 +8,9 @@ use crate::assembly::{index_search, serial_index_search};
 use crate::bounds::Bound as PyBound;
 use crate::loader::parse_molfile_str;
 
-/// Mirrors the `BoundOption` enum in main.rs.
+/// Mirrors the `bounds::Bound` enum.
 // TODO: Is there a clean way of combining these so we don't have to maintain
-// two identical lists? Move to utils?
+// two identical lists?
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum PyBoundOption {
     Log,

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -1,11 +1,6 @@
 //! Test assembly-theory correctness against all reference datasets.
 
-use std::{
-    collections::HashMap,
-    ffi::OsStr,
-    fs,
-    path::Path
-};
+use std::{collections::HashMap, ffi::OsStr, fs, path::Path};
 
 use csv::Reader;
 
@@ -22,8 +17,7 @@ fn load_ma_index(dataset: &str) -> HashMap<String, u32> {
     // Set up CSV reader for data/<dataset>/ma-index.csv.
     let ma_index_path = Path::new("data").join(dataset).join("ma-index.csv");
     let mut reader =
-        Reader::from_path(ma_index_path)
-            .expect(&format!("{dataset}/ma-index.csv does not exist."));
+        Reader::from_path(ma_index_path).expect(&format!("{dataset}/ma-index.csv does not exist."));
 
     // Load assembly index records.
     let mut ma_index: HashMap<String, u32> = HashMap::new();
@@ -65,12 +59,16 @@ fn test_reference_dataset(dataset: &str, bounds: &[Bound], serial: bool) {
 
         // Load the .mol file as an assembly_theory::molecule::Molecule.
         let mol = parse_molfile_str(
-            &fs::read_to_string(name.clone())
-                .expect(&format!("Could not read file {name:?}")),
-        ).expect(&format!("Failed to parse {name:?}"));
+            &fs::read_to_string(name.clone()).expect(&format!("Could not read file {name:?}")),
+        )
+        .expect(&format!("Failed to parse {name:?}"));
 
         // Calculate the molecule's assembly index.
-        let pmode = if serial {ParallelMode::None} else {ParallelMode::Always};
+        let pmode = if serial {
+            ParallelMode::None
+        } else {
+            ParallelMode::Always
+        };
         let (index, _, _) = index_search(
             &mol,
             EnumerateMode::GrowErode,
@@ -78,7 +76,8 @@ fn test_reference_dataset(dataset: &str, bounds: &[Bound], serial: bool) {
             pmode,
             KernelMode::None,
             bounds,
-            false);
+            false,
+        );
 
         // Compare calculated assembly index to ground truth.
         let molname = name.file_name().unwrap().to_str().unwrap().to_string();
@@ -115,11 +114,7 @@ fn gdb13_1201_intbound() {
 
 #[test]
 fn gdb13_1201_allbounds() {
-    let bounds = vec![
-        Bound::Int,
-        Bound::VecSimple,
-        Bound::VecSmallFrags,
-    ];
+    let bounds = vec![Bound::Int, Bound::VecSimple, Bound::VecSmallFrags];
     test_reference_dataset("gdb13_1201", &bounds, false);
 }
 
@@ -140,11 +135,7 @@ fn gdb13_1201_intbound_serial() {
 
 #[test]
 fn gdb13_1201_allbounds_serial() {
-    let bounds = [
-        Bound::Int,
-        Bound::VecSimple,
-        Bound::VecSmallFrags,
-    ];
+    let bounds = [Bound::Int, Bound::VecSimple, Bound::VecSmallFrags];
     test_reference_dataset("gdb13_1201", &bounds, true);
 }
 
@@ -166,11 +157,7 @@ fn gdb17_200_intbound() {
 
 #[test]
 fn gdb17_200_allbounds() {
-    let bounds = [
-        Bound::Int,
-        Bound::VecSimple,
-        Bound::VecSmallFrags,
-    ];
+    let bounds = [Bound::Int, Bound::VecSimple, Bound::VecSmallFrags];
     test_reference_dataset("gdb17_200", &bounds, false);
 }
 
@@ -192,11 +179,7 @@ fn checks_intbound() {
 
 #[test]
 fn checks_allbounds() {
-    let bounds = [
-        Bound::Int,
-        Bound::VecSimple,
-        Bound::VecSmallFrags,
-    ];
+    let bounds = [Bound::Int, Bound::VecSimple, Bound::VecSmallFrags];
     test_reference_dataset("checks", &bounds, false);
 }
 
@@ -221,10 +204,6 @@ fn coconut_55_intbound() {
 #[test]
 #[ignore = "expensive test"]
 fn coconut_55_allbounds() {
-    let bounds = [
-        Bound::Int,
-        Bound::VecSimple,
-        Bound::VecSmallFrags,
-    ];
+    let bounds = [Bound::Int, Bound::VecSimple, Bound::VecSmallFrags];
     test_reference_dataset("coconut_55", &bounds, false);
 }

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -4,7 +4,8 @@ use csv::Reader;
 use std::{collections::HashMap, ffi::OsStr, fs, path::Path};
 
 use assembly_theory::{
-    assembly::{index_search, serial_index_search, Bound},
+    assembly::{index_search, serial_index_search},
+    bounds::Bound,
     loader,
 };
 
@@ -95,15 +96,15 @@ fn gdb13_1201_logbound() {
 
 #[test]
 fn gdb13_1201_intbound() {
-    test_reference_dataset("gdb13_1201", &[Bound::IntChain], false);
+    test_reference_dataset("gdb13_1201", &[Bound::Int], false);
 }
 
 #[test]
 fn gdb13_1201_allbounds() {
     let bounds = vec![
-        Bound::IntChain,
-        Bound::VecChainSimple,
-        Bound::VecChainSmallFrags,
+        Bound::Int,
+        Bound::VecSimple,
+        Bound::VecSmallFrags,
     ];
     test_reference_dataset("gdb13_1201", &bounds, false);
 }
@@ -120,15 +121,15 @@ fn gdb13_1201_logbound_serial() {
 
 #[test]
 fn gdb13_1201_intbound_serial() {
-    test_reference_dataset("gdb13_1201", &[Bound::IntChain], true);
+    test_reference_dataset("gdb13_1201", &[Bound::Int], true);
 }
 
 #[test]
 fn gdb13_1201_allbounds_serial() {
     let bounds = [
-        Bound::IntChain,
-        Bound::VecChainSimple,
-        Bound::VecChainSmallFrags,
+        Bound::Int,
+        Bound::VecSimple,
+        Bound::VecSmallFrags,
     ];
     test_reference_dataset("gdb13_1201", &bounds, true);
 }
@@ -146,15 +147,15 @@ fn gdb17_200_logbound() {
 
 #[test]
 fn gdb17_200_intbound() {
-    test_reference_dataset("gdb17_200", &[Bound::IntChain], false);
+    test_reference_dataset("gdb17_200", &[Bound::Int], false);
 }
 
 #[test]
 fn gdb17_200_allbounds() {
     let bounds = [
-        Bound::IntChain,
-        Bound::VecChainSimple,
-        Bound::VecChainSmallFrags,
+        Bound::Int,
+        Bound::VecSimple,
+        Bound::VecSmallFrags,
     ];
     test_reference_dataset("gdb17_200", &bounds, false);
 }
@@ -172,15 +173,15 @@ fn checks_logbound() {
 
 #[test]
 fn checks_intbound() {
-    test_reference_dataset("checks", &[Bound::IntChain], false);
+    test_reference_dataset("checks", &[Bound::Int], false);
 }
 
 #[test]
 fn checks_allbounds() {
     let bounds = [
-        Bound::IntChain,
-        Bound::VecChainSimple,
-        Bound::VecChainSmallFrags,
+        Bound::Int,
+        Bound::VecSimple,
+        Bound::VecSmallFrags,
     ];
     test_reference_dataset("checks", &bounds, false);
 }
@@ -200,16 +201,16 @@ fn checks_allbounds() {
 #[test]
 #[ignore = "expensive test"]
 fn coconut_55_intbound() {
-    test_reference_dataset("coconut_55", &[Bound::IntChain], false);
+    test_reference_dataset("coconut_55", &[Bound::Int], false);
 }
 
 #[test]
 #[ignore = "expensive test"]
 fn coconut_55_allbounds() {
     let bounds = [
-        Bound::IntChain,
-        Bound::VecChainSimple,
-        Bound::VecChainSmallFrags,
+        Bound::Int,
+        Bound::VecSimple,
+        Bound::VecSmallFrags,
     ];
     test_reference_dataset("coconut_55", &bounds, false);
 }

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -14,6 +14,7 @@ use assembly_theory::{
     bounds::Bound,
     canonize::CanonizeMode,
     enumerate::EnumerateMode,
+    kernels::KernelMode,
     loader::parse_molfile_str,
 };
 
@@ -75,7 +76,9 @@ fn test_reference_dataset(dataset: &str, bounds: &[Bound], serial: bool) {
             EnumerateMode::GrowErode,
             CanonizeMode::Nauty,
             pmode,
-            bounds);
+            KernelMode::None,
+            bounds,
+            false);
 
         // Compare calculated assembly index to ground truth.
         let molname = name.file_name().unwrap().to_str().unwrap().to_string();


### PR DESCRIPTION
- `canonization.rs` now has three new functions: `grow_erode_iterative`, `matches_by_iterative_expansion`, and `naive_matches_by_iterative_expansion`. These functions have not been plugged into the rest of our code. The latter two functions produce the entire `matches` object from an input `molecule`. They need to be split up.
- `recurse-index-search-parallel` uses an `Arc<AtomicUsize>` to share `best_index` between threads.