### PR TITLE
Implement depth-one parallelization

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -389,7 +389,7 @@ fn recurse_index_search_parallel(
     matches: &[(BitSet, BitSet)],
     fragments: &[BitSet],
     state_index: usize,
-    best_index: AtomicUsize,
+    best_index: Arc<AtomicUsize>,
     largest_remove: usize,
     bounds: &[Bound],
     states_searched: Arc<AtomicUsize>,
@@ -458,7 +458,7 @@ fn recurse_index_search_parallel(
             &matches[i + 1..],
             &fractures,
             state_index - h1.len() + 1,
-            best_index.load(Relaxed).into(),
+            best_index.clone(),
             largest_remove,
             bounds,
             states_searched.clone(),
@@ -589,12 +589,13 @@ pub fn index_search(
         }
         ParallelMode::Always => {
             let states_searched = Arc::new(AtomicUsize::from(0));
+            let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
             let index = recurse_index_search_parallel(
                 mol,
                 &matches,
                 &[init],
                 edge_count - 1,
-                (edge_count - 1).into(),
+                best_index,
                 edge_count,
                 bounds,
                 states_searched.clone(),

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -107,7 +107,7 @@ fn matches(
 
     // Sort pairs in a deterministic order and return.
     matches.sort_by(|e1, e2| {
-        let ord = vec![
+        let ord = [
             e2.0.len().cmp(&e1.0.len()), // Decreasing subgraph size.
             e1.0.cmp(&e2.0),             // First subgraph lexicographical.
             e1.1.cmp(&e2.1),             // Second subgraph lexicographical.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ struct Cli {
     canonize: CanonizeMode,
 
     /// Parallelization strategy for the search phase.
-    #[arg(long, value_enum, default_value_t = ParallelMode::Always)]
+    #[arg(long, value_enum, default_value_t = ParallelMode::DepthOne)]
     parallel: ParallelMode,
 
     /// Use dynamic programming memoization in the search phase.


### PR DESCRIPTION
Resolves #71.

- Implements `ParallelMode::DepthOne` where search threads are spawned only at the first level of recursion
- Improves thread sharing of parallel counting variables for all parallel modes
- Removes `PARALLEL_MATCH_SIZE_THRESHOLD` enforcing serial execution for small molecules
- Totally orders matches during enumeration to support deterministic serial iteration
- Refactors fracture computation (i.e., getting the next assembly state from the current one) to avoid duplicate code