### PR TITLE
Implement new enumeration variants

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -28,6 +28,7 @@ use std::{
 
 use bit_set::BitSet;
 use clap::ValueEnum;
+use petgraph::graph::EdgeIndex;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
@@ -36,7 +37,7 @@ use crate::{
     enumerate::{enumerate_subgraphs, EnumerateMode},
     kernels::KernelMode,
     molecule::Molecule,
-    utils::connected_components_under_edges,
+    utils::{connected_components_under_edges, edge_neighbors},
 };
 
 /// Parallelization strategy for the search phase.
@@ -74,11 +75,42 @@ pub fn assembly_depth(mol: &Molecule) -> u32 {
 
 /// Return an iterator over all pairs of non-overlapping, isomorphic subgraphs
 /// in the given molecule, sorted to guarantee deterministic iteration.
+// The reason this is split up is because EnumerateMode::ExtendIsomorphic
+// interleaves subgraph enumeration and isomorphism class construction instead
+// of splitting them into two steps like the rest of the enumeration modes.
 fn matches(
     mol: &Molecule,
     enumerate_mode: EnumerateMode,
     canonize_mode: CanonizeMode,
 ) -> impl Iterator<Item = (BitSet, BitSet)> {
+    let mut matches = if enumerate_mode == EnumerateMode::ExtendIsomorphic {
+        matches_extend_isomorphic(mol, canonize_mode)
+    } else {
+        matches_general(mol, enumerate_mode, canonize_mode)
+    };
+
+    // Sort pairs in a deterministic order and return.
+    matches.sort_by(|e1, e2| {
+        let ord = [
+            e2.0.len().cmp(&e1.0.len()), // Decreasing subgraph size.
+            e1.0.cmp(&e2.0),             // First subgraph lexicographical.
+            e1.1.cmp(&e2.1),             // Second subgraph lexicographical.
+        ];
+        let mut i = 0;
+        while ord[i] == std::cmp::Ordering::Equal {
+            i += 1;
+        }
+        ord[i]
+    });
+
+    matches.into_iter()
+}
+
+fn matches_general(
+    mol: &Molecule,
+    enumerate_mode: EnumerateMode,
+    canonize_mode: CanonizeMode,
+) -> Vec<(BitSet, BitSet)> {
     // Enumerate all connected, non-induced subgraphs and bin them into
     // isomorphism classes using canonization.
     let mut isomorphic_map = HashMap::<_, Vec<BitSet>>::new();
@@ -105,20 +137,86 @@ fn matches(
         }
     }
 
-    // Sort pairs in a deterministic order and return.
-    matches.sort_by(|e1, e2| {
-        let ord = [
-            e2.0.len().cmp(&e1.0.len()), // Decreasing subgraph size.
-            e1.0.cmp(&e2.0),             // First subgraph lexicographical.
-            e1.1.cmp(&e2.1),             // Second subgraph lexicographical.
-        ];
-        let mut i = 0;
-        while ord[i] == std::cmp::Ordering::Equal {
-            i += 1;
+    matches
+}
+
+/// Enumerate connected, non-induced subgraphs with at most |E|/2 edges which
+/// are isomorphic to at least one other subgraph (i.e., the subgraphs that
+/// have a chance of being in a non-overlapping, isomorphic subgraph pair later
+/// on). Uses a similar iterative extension process to extend_iterative, but at
+/// each level, removes any subgraphs in singleton isomorphism classes. 
+fn matches_extend_isomorphic(
+    mol: &Molecule,
+    canonize_mode: CanonizeMode
+) -> Vec<(BitSet, BitSet)> {
+    // Set up a container for pairs of non-overlapping, isomorphic subgraphs.
+    let mut matches = Vec::new();
+
+    // Maintain a map of subgraphs to their "frontiers" (i.e., a subgraph's
+    // edges and its edge boundary), starting with all edges individually.
+    let mut subgraphs: HashMap<BitSet, BitSet> =
+        HashMap::from_iter(mol.graph().edge_indices().map(|ix| {
+            let mut subgraph = BitSet::new();
+            subgraph.insert(ix.index());
+            let frontier = BitSet::from_iter(edge_neighbors(mol.graph(), ix).map(|e| e.index()));
+            (subgraph, frontier)
+        }));
+
+    // Enumerate and bin subgraphs by "levels" up to |E|/2, as in extend().
+    for _ in 0..(mol.graph().edge_count() / 2) {
+        // Collect and deduplicate all subgraphs obtained by extending an
+        // existing subgraph using one edge from its boundary.
+        let mut extended_subgraphs = HashMap::new();
+        for (subgraph, frontier) in subgraphs {
+            for edge in frontier.difference(&subgraph) {
+                let mut extended_subgraph = subgraph.clone();
+                extended_subgraph.insert(edge);
+                if !extended_subgraphs.contains_key(&extended_subgraph) {
+                    let mut extended_frontier = frontier.clone();
+                    extended_frontier.extend(
+                        edge_neighbors(mol.graph(), EdgeIndex::new(edge)).map(|e| e.index()),
+                    );
+                    extended_subgraphs.insert(extended_subgraph, extended_frontier);
+                }
+            }
         }
-        ord[i]
-    });
-    matches.into_iter()
+
+        // Bin the new subgraphs into isomorphism classes using canonization.
+        let mut isomorphic_map = HashMap::<_, Vec<BitSet>>::new();
+        for (subgraph, _) in &extended_subgraphs {
+            isomorphic_map
+                .entry(canonize(mol, &subgraph, canonize_mode))
+                .and_modify(|bucket| bucket.push(subgraph.clone()))
+                .or_insert(vec![subgraph.clone()]);
+        }
+
+        // Drop any subgraphs in singleton isomorphism classes and use these to
+        // seed the next level of subgraph extensions.
+        for (_, iso_class) in &isomorphic_map {
+            if iso_class.len() == 1 {
+                extended_subgraphs.remove(&iso_class[0]);
+            }
+        }
+        subgraphs = extended_subgraphs;
+
+        // In each isomorphism class, collect non-overlapping pairs of
+        // subgraphs, skipping singleton edges (basic units).
+        for bucket in isomorphic_map.values() {
+            for (i, first) in bucket.iter().enumerate() {
+                for second in &bucket[i..] {
+                    if first.is_disjoint(second) {
+                        if first > second {
+                            matches.push((first.clone(), second.clone()));
+                        } else {
+                            matches.push((second.clone(), first.clone()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    matches
 }
 
 /// Determine the fragments produced by removing the given pair of duplicatable

--- a/src/canonize.rs
+++ b/src/canonize.rs
@@ -54,7 +54,7 @@ pub fn canonize(mol: &Molecule, subgraph: &BitSet, mode: CanonizeMode) -> Labeli
 type CGraph = Graph<AtomOrBond, (), Undirected, Index>;
 
 /// Convert the specified `subgraph` to the format expected by Nauty.
-pub(crate) fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
+fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
     let mut h = CGraph::with_capacity(subgraph.len(), 2 * subgraph.len());
     let mut vtx_map = HashMap::<NodeIndex, NodeIndex>::new();
     for e in subgraph {

--- a/src/canonize.rs
+++ b/src/canonize.rs
@@ -54,7 +54,7 @@ pub fn canonize(mol: &Molecule, subgraph: &BitSet, mode: CanonizeMode) -> Labeli
 type CGraph = Graph<AtomOrBond, (), Undirected, Index>;
 
 /// Convert the specified `subgraph` to the format expected by Nauty.
-fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
+pub(crate) fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
     let mut h = CGraph::with_capacity(subgraph.len(), 2 * subgraph.len());
     let mut vtx_map = HashMap::<NodeIndex, NodeIndex>::new();
     for e in subgraph {

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -173,19 +173,13 @@ fn grow_erode(mol: &Molecule) -> HashSet<BitSet> {
     // Set up a set of subgraphs enumerated so far.
     let mut subgraphs = HashSet::new();
 
-    // Maintain a stack of subgraph instances to extend. The fourth member of
-    // these instance tuples is the index of the first edge that was ever added
-    // to the subgraph. This is used to avoid multiply enumerating subgraphs.
-    let mut stack = vec![(subgraph, frontier, remainder, 0)];
-    while let Some((mut subgraph, mut frontier, mut remainder, mut first)) = stack.pop() {
+    // Maintain a stack of subgraph instances to extend.
+    let mut stack = vec![(subgraph, frontier, remainder)];
+    while let Some((mut subgraph, mut frontier, mut remainder)) = stack.pop() {
         // Get the next edge from the subgraph's edge boundary or, if the
         // subgraph is empty, from the remainder.
         let candidate = if subgraph.is_empty() {
-            let e_iter = remainder.iter().next();
-            if let Some(e) = e_iter {
-                first = e;
-            }
-            e_iter
+            remainder.iter().next()
         } else {
             remainder.intersection(&frontier).next()
         };
@@ -193,16 +187,16 @@ fn grow_erode(mol: &Molecule) -> HashSet<BitSet> {
         if let Some(e) = candidate {
             // Make a new instance by discarding the candidate edge entirely.
             remainder.remove(e);
-            stack.push((subgraph.clone(), frontier.clone(), remainder.clone(), first));
+            stack.push((subgraph.clone(), frontier.clone(), remainder.clone()));
 
             // Make another instance by adding the candidate edge to the
             // subgraph and updating the frontier accordingly if the new
             // subgraph was not previously enumerated and is not too large to
             // be part of a non-overlapping isomorphic pair.
-            if (subgraph.is_empty() || e > first) && subgraph.len() < mol.graph().edge_count() / 2 {
-                subgraph.insert(e);
+            subgraph.insert(e);
+            if !subgraphs.contains(&subgraph) && subgraph.len() <= mol.graph().edge_count() / 2 {
                 frontier.extend(edge_neighbors(mol.graph(), EdgeIndex::new(e)).map(|ix| ix.index()));
-                stack.push((subgraph, frontier, remainder, first));
+                stack.push((subgraph, frontier, remainder));
             }
         } else if subgraph.len() > 1 {
             // When all candidate edges are exhausted, collect this subgraph

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -1,12 +1,17 @@
 //! Enumerate connected, non-induced subgraphs of a molecular graph.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use bit_set::BitSet;
 use clap::ValueEnum;
+use graph_canon::CanonLabeling;
 use petgraph::graph::EdgeIndex;
 
-use crate::molecule::Molecule;
+use crate::{
+    canonize::subgraph_to_cgraph,
+    molecule::{AtomOrBond, Molecule},
+    utils::edge_neighbors,
+};
 
 /// Strategy for enumerating connected, non-induced subgraphs.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]
@@ -93,20 +98,7 @@ fn recurse_grow_erode(
             subset.insert(e);
 
             // Grow the boundary to include edges incident to the candidate.
-            let (src, dst) = mol
-                .graph()
-                .edge_endpoints(EdgeIndex::new(e))
-                .expect("malformed input");
-            subsetplus.extend(
-                mol.graph()
-                    .neighbors(src)
-                    .filter_map(|n| mol.graph().find_edge(src, n).map(|ix| ix.index())),
-            );
-            subsetplus.extend(
-                mol.graph()
-                    .neighbors(dst)
-                    .filter_map(|n| mol.graph().find_edge(dst, n).map(|ix| ix.index())),
-            );
+            subsetplus.extend(edge_neighbors(&mol.graph(), EdgeIndex::new(e)).map(|ix| ix.index()));
 
             // Recurse.
             recurse_grow_erode(mol, subset, subsetplus, remainder, subgraphs);
@@ -116,4 +108,160 @@ fn recurse_grow_erode(
         // new subgraph if it is nonempty.
         subgraphs.insert(subset);
     }
+}
+
+// Iterative version of grow_erode_recurse
+fn grow_erode_iterative(mol: &Molecule) -> impl Iterator<Item = BitSet> {
+    let remainder = BitSet::from_iter(mol.graph().edge_indices().map(|ix| ix.index()));
+    let subset = BitSet::new();
+    let neighbors = BitSet::new();
+    let mut stack = vec![(subset, neighbors, remainder)];
+
+    let mut solutions = HashSet::new();
+
+    while let Some((mut subset, mut neighbors, mut remainder)) = stack.pop() {
+        let candidate = if subset.is_empty() {
+            remainder.iter().next()
+        } else {
+            remainder.intersection(&neighbors).next()
+        };
+
+        if let Some(e) = candidate {
+            remainder.remove(e);
+            stack.push((subset.clone(), neighbors.clone(), remainder.clone()));
+
+            subset.insert(e);
+            if solutions.contains(&subset) || subset.len() > mol.graph().edge_count() / 2 {
+                continue;
+            }
+
+            neighbors.extend(edge_neighbors(mol.graph(), EdgeIndex::new(e)).map(|ix| ix.index()));
+            stack.push((subset, neighbors, remainder));
+        } else if subset.len() > 1 {
+            solutions.insert(subset);
+        }
+    }
+    solutions.into_iter()
+}
+
+// TODO: matches_by_iterative_expansion and naive_matches_by_iterative_expansion are big, ugly
+// functions that need to be split up and cleaned.
+pub fn matches_by_iterative_expansion(mol: &Molecule) -> impl Iterator<Item = (BitSet, BitSet)> {
+    let mut solutions: HashMap<BitSet, BitSet> =
+        HashMap::from_iter(mol.graph().edge_indices().map(|ix| {
+            let mut set = BitSet::new();
+            set.insert(ix.index());
+            let neighborhood =
+                BitSet::from_iter(edge_neighbors(&mol.graph(), ix).map(|e| e.index()));
+            (set, neighborhood)
+        }));
+
+    let mut matches = Vec::new();
+
+    for _ in 0..(mol.graph().edge_count() / 2) {
+        let mut next_set = HashMap::new();
+        for (subgraph, neighborhood) in solutions {
+            for neighbor in neighborhood.difference(&subgraph) {
+                if subgraph.contains(neighbor) {
+                    continue;
+                }
+
+                let mut next = subgraph.clone();
+                next.insert(neighbor);
+
+                if next_set.contains_key(&next) {
+                    continue;
+                }
+
+                let mut next_neighborhood = neighborhood.clone();
+                next_neighborhood.extend(
+                    edge_neighbors(&mol.graph(), EdgeIndex::new(neighbor)).map(|e| e.index()),
+                );
+
+                next_set.insert(next, next_neighborhood);
+            }
+        }
+
+        let mut local_isomorphic_map = HashMap::<CanonLabeling<AtomOrBond>, Vec<BitSet>>::new();
+        for (subgraph, _) in &next_set {
+            let cgraph = subgraph_to_cgraph(mol, &subgraph);
+            let repr = CanonLabeling::new(&cgraph);
+
+            local_isomorphic_map
+                .entry(repr)
+                .and_modify(|bucket| bucket.push(subgraph.clone()))
+                .or_insert(vec![subgraph.clone()]);
+        }
+
+        for (_, sets) in &local_isomorphic_map {
+            if sets.len() == 1 {
+                next_set.remove(&sets[0]);
+            }
+        }
+
+        solutions = next_set;
+        for bucket in local_isomorphic_map.values().filter(|v| v.len() > 1) {
+            for (i, first) in bucket.iter().enumerate() {
+                for second in &bucket[i..] {
+                    if first.is_disjoint(second) {
+                        matches.push((first.clone(), second.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    matches.into_iter()
+}
+
+pub fn naive_matches_by_iterative_expansion(
+    mol: &Molecule,
+) -> impl Iterator<Item = (BitSet, BitSet)> {
+    let mut solutions: Vec<HashSet<BitSet>> =
+        vec![HashSet::from_iter(mol.graph().edge_indices().map(|ix| {
+            let mut set = BitSet::new();
+            set.insert(ix.index());
+            set
+        }))];
+
+    for ix in 0..(mol.graph().edge_count() / 2) {
+        let mut nexts = HashSet::new();
+        for subgraph in &solutions[ix] {
+            let neighborhood = BitSet::from_iter(
+                mol.graph()
+                    .edge_indices()
+                    .map(|ix| edge_neighbors(&mol.graph(), ix).map(|e| e.index()))
+                    .flatten(),
+            );
+            for neighbor in neighborhood.difference(&subgraph) {
+                let mut next = subgraph.clone();
+                next.insert(neighbor);
+                nexts.insert(next);
+            }
+        }
+        solutions.push(nexts);
+    }
+
+    let mut isomorphic_map = HashMap::<CanonLabeling<AtomOrBond>, Vec<BitSet>>::new();
+    for subgraph in solutions.into_iter().skip(1).flatten() {
+        let cgraph = subgraph_to_cgraph(mol, &subgraph);
+        let repr = CanonLabeling::new(&cgraph);
+
+        isomorphic_map
+            .entry(repr)
+            .and_modify(|bucket| bucket.push(subgraph.clone()))
+            .or_insert(vec![subgraph.clone()]);
+    }
+
+    let mut matches = Vec::new();
+    for bucket in isomorphic_map.values() {
+        for (i, first) in bucket.iter().enumerate() {
+            for second in &bucket[i..] {
+                if first.is_disjoint(second) {
+                    matches.push((first.clone(), second.clone()));
+                }
+            }
+        }
+    }
+    matches.into_iter()
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -22,7 +22,6 @@ enum PyEnumerateMode {
     Extend,
     ExtendIsomorphic,
     GrowErode,
-    GrowErodeIterative,
 }
 
 /// Mirrors the `canonize::CanonizeMode` enum.
@@ -72,7 +71,6 @@ impl FromStr for PyEnumerateMode {
             "extend" => Ok(PyEnumerateMode::Extend),
             "extendisomorphic" => Ok(PyEnumerateMode::ExtendIsomorphic),
             "growerode" => Ok(PyEnumerateMode::GrowErode),
-            "growerodeiterative" => Ok(PyEnumerateMode::GrowErodeIterative),
             _ => Err(PyValueError::new_err(format!("Invalid enumerate: {s}"))),
         }
     }
@@ -249,7 +247,6 @@ pub fn _index_search(
         Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
         Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
-        Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")
         }
@@ -339,7 +336,6 @@ pub fn _index_search_verbose(
         Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
         Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
-        Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -19,8 +19,8 @@ use crate::{
 /// Mirrors the `enumerate::EnumerateMode` enum.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum PyEnumerateMode {
-    Bfs,
-    BfsPrune,
+    Extend,
+    ExtendPrune,
     GrowErode,
     GrowErodeIterative,
 }
@@ -69,8 +69,8 @@ impl FromStr for PyEnumerateMode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "bfs" => Ok(PyEnumerateMode::Bfs),
-            "bfsprune" => Ok(PyEnumerateMode::BfsPrune),
+            "extend" => Ok(PyEnumerateMode::Extend),
+            "extendprune" => Ok(PyEnumerateMode::ExtendPrune),
             "growerode" => Ok(PyEnumerateMode::GrowErode),
             "growerodeiterative" => Ok(PyEnumerateMode::GrowErodeIterative),
             _ => Err(PyValueError::new_err(format!("Invalid enumerate: {s}"))),
@@ -246,8 +246,8 @@ pub fn _index_search(
 
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
-        Ok(PyEnumerateMode::Bfs) => EnumerateMode::Bfs,
-        Ok(PyEnumerateMode::BfsPrune) => EnumerateMode::BfsPrune,
+        Ok(PyEnumerateMode::Extend) => EnumerateMode::ExtendPrune,
+        Ok(PyEnumerateMode::ExtendPrune) => EnumerateMode::ExtendPrune,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
@@ -336,8 +336,8 @@ pub fn _index_search_verbose(
 
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
-        Ok(PyEnumerateMode::Bfs) => EnumerateMode::Bfs,
-        Ok(PyEnumerateMode::BfsPrune) => EnumerateMode::BfsPrune,
+        Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
+        Ok(PyEnumerateMode::ExtendPrune) => EnumerateMode::ExtendPrune,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {

--- a/src/python.rs
+++ b/src/python.rs
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum PyEnumerateMode {
     Extend,
-    ExtendPrune,
+    ExtendIsomorphic,
     GrowErode,
     GrowErodeIterative,
 }
@@ -70,7 +70,7 @@ impl FromStr for PyEnumerateMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "extend" => Ok(PyEnumerateMode::Extend),
-            "extendprune" => Ok(PyEnumerateMode::ExtendPrune),
+            "extendisomorphic" => Ok(PyEnumerateMode::ExtendIsomorphic),
             "growerode" => Ok(PyEnumerateMode::GrowErode),
             "growerodeiterative" => Ok(PyEnumerateMode::GrowErodeIterative),
             _ => Err(PyValueError::new_err(format!("Invalid enumerate: {s}"))),
@@ -246,8 +246,8 @@ pub fn _index_search(
 
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
-        Ok(PyEnumerateMode::Extend) => EnumerateMode::ExtendPrune,
-        Ok(PyEnumerateMode::ExtendPrune) => EnumerateMode::ExtendPrune,
+        Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
+        Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {
@@ -337,7 +337,7 @@ pub fn _index_search_verbose(
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
         Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
-        Ok(PyEnumerateMode::ExtendPrune) => EnumerateMode::ExtendPrune,
+        Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         Ok(PyEnumerateMode::GrowErodeIterative) => EnumerateMode::GrowErodeIterative,
         _ => {


### PR DESCRIPTION
Resolves #69 and #81.

- Replaces the existing recursive `EnumerateMode::GrowErode` with an iterative version that avoids enumerating any subgraphs multiple times (and removes the `EnumerateMode::GrowErodeIterative` option). This remains the default.
- Implements and enables `EnumerateMode::Extend` (previously `Bfs`).
- Implements and enables `EnumerateMode::ExtendIsomorphic` (previously `BfsPrune`), though because this method interleaves enumeration and canonization, it lives in `assembly` instead of `enumerate` as an alternative match generation function.

Notably, @Garrett-Pz had an alternative idea for avoiding redundant enumeration for `EnumerateMode::GrowErode` (see commit [`ce603ab`](https://github.com/DaymudeLab/assembly-theory/commit/ce603abd476d14499fbc19c38af079a64f06ad9f)), but preliminary tests on `stress/space_PAH.mol` don't suggest that this was any more time or memory efficient than the currently implemented `HashMap` approach. So the commit exists in the PR for posterity but was reverted.