### PR TITLE
Canonize subgraphs only once (and remove ExtendIsomorphic enumeration)

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -88,18 +88,12 @@ fn labels_matches(
     let mut isomorphism_classes = HashMap::<Labeling, Vec<BitSet>>::new();
     let mut subgraph_labels = HashMap::<BitSet, Labeling>::new();
     for subgraph in enumerate_subgraphs(mol, enumerate_mode) {
-        // TODO: Because canonize::Labeling does not implement Copy or Clone,
-        // but we want to use the canonical label in two places, we have to
-        // compute it twice. Implementing Copy or Clone on canonize::Labeling
-        // requires modifying graph_canon::CanonLabeling which we don't have
-        // access to. Update this after a fix is implemented.
         let label = canonize(mol, &subgraph, canonize_mode);
-        let label2 = canonize(mol, &subgraph, canonize_mode);
         isomorphism_classes
-            .entry(label)
+            .entry(label.clone())
             .and_modify(|bucket| bucket.push(subgraph.clone()))
             .or_insert(vec![subgraph.clone()]);
-        subgraph_labels.insert(subgraph, label2);
+        subgraph_labels.insert(subgraph, label);
     }
 
     // In each isomorphism class, collect non-overlapping pairs of subgraphs.

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -28,7 +28,6 @@ use std::{
 
 use bit_set::BitSet;
 use clap::ValueEnum;
-use petgraph::graph::EdgeIndex;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
@@ -37,7 +36,7 @@ use crate::{
     enumerate::{enumerate_subgraphs, EnumerateMode},
     kernels::KernelMode,
     molecule::Molecule,
-    utils::{connected_components_under_edges, edge_neighbors},
+    utils::connected_components_under_edges,
 };
 
 /// Parallelization strategy for the search phase.
@@ -75,19 +74,36 @@ pub fn assembly_depth(mol: &Molecule) -> u32 {
 
 /// Return an iterator over all pairs of non-overlapping, isomorphic subgraphs
 /// in the given molecule, sorted to guarantee deterministic iteration.
-// The reason this is split up is because EnumerateMode::ExtendIsomorphic
-// interleaves subgraph enumeration and isomorphism class construction instead
-// of splitting them into two steps like the rest of the enumeration modes.
 fn matches(
     mol: &Molecule,
     enumerate_mode: EnumerateMode,
     canonize_mode: CanonizeMode,
 ) -> impl Iterator<Item = (BitSet, BitSet)> {
-    let mut matches = if enumerate_mode == EnumerateMode::ExtendIsomorphic {
-        matches_extend_isomorphic(mol, canonize_mode)
-    } else {
-        matches_general(mol, enumerate_mode, canonize_mode)
-    };
+    // Enumerate all connected, non-induced subgraphs and bin them into
+    // isomorphism classes using canonization.
+    let mut isomorphism_classes = HashMap::<_, Vec<BitSet>>::new();
+    for subgraph in enumerate_subgraphs(mol, enumerate_mode) {
+        isomorphism_classes
+            .entry(canonize(mol, &subgraph, canonize_mode))
+            .and_modify(|bucket| bucket.push(subgraph.clone()))
+            .or_insert(vec![subgraph.clone()]);
+    }
+
+    // In each isomorphism class, collect non-overlapping pairs of subgraphs.
+    let mut matches = Vec::new();
+    for bucket in isomorphism_classes.values() {
+        for (i, first) in bucket.iter().enumerate() {
+            for second in &bucket[i..] {
+                if first.is_disjoint(second) {
+                    if first > second {
+                        matches.push((first.clone(), second.clone()));
+                    } else {
+                        matches.push((second.clone(), first.clone()));
+                    }
+                }
+            }
+        }
+    }
 
     // Sort pairs in a deterministic order and return.
     matches.sort_by(|e1, e2| {
@@ -104,118 +120,6 @@ fn matches(
     });
 
     matches.into_iter()
-}
-
-fn matches_general(
-    mol: &Molecule,
-    enumerate_mode: EnumerateMode,
-    canonize_mode: CanonizeMode,
-) -> Vec<(BitSet, BitSet)> {
-    // Enumerate all connected, non-induced subgraphs and bin them into
-    // isomorphism classes using canonization.
-    let mut isomorphic_map = HashMap::<_, Vec<BitSet>>::new();
-    for subgraph in enumerate_subgraphs(mol, enumerate_mode) {
-        isomorphic_map
-            .entry(canonize(mol, &subgraph, canonize_mode))
-            .and_modify(|bucket| bucket.push(subgraph.clone()))
-            .or_insert(vec![subgraph.clone()]);
-    }
-
-    // In each isomorphism class, collect non-overlapping pairs of subgraphs.
-    let mut matches = Vec::new();
-    for bucket in isomorphic_map.values() {
-        for (i, first) in bucket.iter().enumerate() {
-            for second in &bucket[i..] {
-                if first.is_disjoint(second) {
-                    if first > second {
-                        matches.push((first.clone(), second.clone()));
-                    } else {
-                        matches.push((second.clone(), first.clone()));
-                    }
-                }
-            }
-        }
-    }
-
-    matches
-}
-
-/// Enumerate connected, non-induced subgraphs with at most |E|/2 edges which
-/// are isomorphic to at least one other subgraph (i.e., the subgraphs that
-/// have a chance of being in a non-overlapping, isomorphic subgraph pair later
-/// on). Uses a similar iterative extension process to extend_iterative, but at
-/// each level, removes any subgraphs in singleton isomorphism classes.
-fn matches_extend_isomorphic(mol: &Molecule, canonize_mode: CanonizeMode) -> Vec<(BitSet, BitSet)> {
-    // Set up a container for pairs of non-overlapping, isomorphic subgraphs.
-    let mut matches = Vec::new();
-
-    // Maintain a map of subgraphs to their "frontiers" (i.e., a subgraph's
-    // edges and its edge boundary), starting with all edges individually.
-    let mut subgraphs: HashMap<BitSet, BitSet> =
-        HashMap::from_iter(mol.graph().edge_indices().map(|ix| {
-            let mut subgraph = BitSet::new();
-            subgraph.insert(ix.index());
-            let frontier = BitSet::from_iter(edge_neighbors(mol.graph(), ix).map(|e| e.index()));
-            (subgraph, frontier)
-        }));
-
-    // Enumerate and bin subgraphs by "levels" up to |E|/2, as in extend().
-    for _ in 0..(mol.graph().edge_count() / 2) {
-        // Collect and deduplicate all subgraphs obtained by extending an
-        // existing subgraph using one edge from its boundary.
-        let mut extended_subgraphs = HashMap::new();
-        for (subgraph, frontier) in subgraphs {
-            for edge in frontier.difference(&subgraph) {
-                let mut extended_subgraph = subgraph.clone();
-                extended_subgraph.insert(edge);
-                extended_subgraphs
-                    .entry(extended_subgraph)
-                    .or_insert_with(|| {
-                        let mut extended_frontier = frontier.clone();
-                        extended_frontier.extend(
-                            edge_neighbors(mol.graph(), EdgeIndex::new(edge)).map(|e| e.index()),
-                        );
-                        extended_frontier
-                    });
-            }
-        }
-
-        // Bin the new subgraphs into isomorphism classes using canonization.
-        let mut isomorphic_map = HashMap::<_, Vec<BitSet>>::new();
-        for subgraph in extended_subgraphs.keys() {
-            isomorphic_map
-                .entry(canonize(mol, subgraph, canonize_mode))
-                .and_modify(|bucket| bucket.push(subgraph.clone()))
-                .or_insert(vec![subgraph.clone()]);
-        }
-
-        // Drop any subgraphs in singleton isomorphism classes and use these to
-        // seed the next level of subgraph extensions.
-        for iso_class in isomorphic_map.values() {
-            if iso_class.len() == 1 {
-                extended_subgraphs.remove(&iso_class[0]);
-            }
-        }
-        subgraphs = extended_subgraphs;
-
-        // In each isomorphism class, collect non-overlapping pairs of
-        // subgraphs, skipping singleton edges (basic units).
-        for bucket in isomorphic_map.values() {
-            for (i, first) in bucket.iter().enumerate() {
-                for second in &bucket[i..] {
-                    if first.is_disjoint(second) {
-                        if first > second {
-                            matches.push((first.clone(), second.clone()));
-                        } else {
-                            matches.push((second.clone(), first.clone()));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    matches
 }
 
 /// Determine the fragments produced by removing the given pair of duplicatable

--- a/src/canonize.rs
+++ b/src/canonize.rs
@@ -26,7 +26,7 @@ pub enum CanonizeMode {
 }
 
 /// Canonical label returned by our graph canonization functions.
-#[derive(Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
 pub enum Labeling {
     /// The label returned by the graph_canon crate.
     Nauty(CanonLabeling<AtomOrBond>),

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -18,9 +18,6 @@ use crate::{molecule::Molecule, utils::edge_neighbors};
 pub enum EnumerateMode {
     /// Grow connected subgraphs from each edge using iterative extension.
     Extend,
-    /// Like Extend, but only extends subgraphs that are isomoprhic to at least
-    /// one other subgraph.
-    ExtendIsomorphic,
     /// From a subgraph, choose an edge from its boundary and either grow it by
     /// adding this edge or erode its remainder by discarding the edge.
     GrowErode,
@@ -31,9 +28,6 @@ pub enum EnumerateMode {
 pub fn enumerate_subgraphs(mol: &Molecule, mode: EnumerateMode) -> impl Iterator<Item = BitSet> {
     match mode {
         EnumerateMode::Extend => extend(mol).into_iter(),
-        EnumerateMode::ExtendIsomorphic => {
-            panic!("EnumerateMode::ExtendIsomorphic gets handled in assembly::matches_extend_isomorphic; execution should never have gotten here!")
-        }
         EnumerateMode::GrowErode => grow_erode(mol).into_iter(),
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -20,7 +20,6 @@ use crate::{
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 enum PyEnumerateMode {
     Extend,
-    ExtendIsomorphic,
     GrowErode,
 }
 
@@ -69,7 +68,6 @@ impl FromStr for PyEnumerateMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "extend" => Ok(PyEnumerateMode::Extend),
-            "extendisomorphic" => Ok(PyEnumerateMode::ExtendIsomorphic),
             "growerode" => Ok(PyEnumerateMode::GrowErode),
             _ => Err(PyValueError::new_err(format!("Invalid enumerate: {s}"))),
         }
@@ -245,7 +243,6 @@ pub fn _index_search(
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
         Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
-        Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")
@@ -334,7 +331,6 @@ pub fn _index_search_verbose(
     // Parse the various modes and bound options.
     let enumerate_mode = match PyEnumerateMode::from_str(&enumerate_str) {
         Ok(PyEnumerateMode::Extend) => EnumerateMode::Extend,
-        Ok(PyEnumerateMode::ExtendIsomorphic) => EnumerateMode::ExtendIsomorphic,
         Ok(PyEnumerateMode::GrowErode) => EnumerateMode::GrowErode,
         _ => {
             panic!("Unrecognized enumerate mode {enumerate_str}.")


### PR DESCRIPTION
- Stores the canonical labels of enumerated subgraphs in a `HashMap<BitSet, Labeling>` that can be used in other parts of the algorithm (e.g., in memoization).
- Removes the `EnumerateMode::ExtendIsomorphic` mode, as it was causing architecture annoyances. In practice, it was only a little faster than `EnumerateMode::Extend` and was nowhere close to `EnumerateMode::GrowErode`, which now provably only enumerates each subgraph of interest once.