### PR TITLE
Implement a reduction to the maximum weighted clique problem

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -28,7 +28,7 @@ use std::{
 
 use bit_set::BitSet;
 use clap::ValueEnum;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
     bounds::{bound_exceeded, Bound},
@@ -220,7 +220,7 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 pub fn recurse_index_search(
     mol: &Molecule,
     matches: &Vec<(BitSet, BitSet)>,
-    graph: &CompatGraph,
+    graph: &Option<CompatGraph>,
     subgraph: BitSet,
     state: &[BitSet],
     state_index: usize,
@@ -259,13 +259,16 @@ pub fn recurse_index_search(
                 parallel_mode
             };
 
-            // TODO: should create a method for updating subgraph
+            // Update subgraph
             let mut sub_clone = BitSet::with_capacity(matches.len());
-            /*let mut node = subgraph.iter().next().unwrap();
-            for j in (i+1)..matches.len() {
-                sub_clone.insert(j);
-            }*/
-            sub_clone.intersect_with(&graph.forward_neighbors(v, &subgraph));
+            if let Some(g) = graph {
+                sub_clone.intersect_with(&g.forward_neighbors(v, &subgraph));
+            }
+            else {
+                for j in (v+1)..matches.len() {
+                    sub_clone.insert(j);
+                }
+            }
 
             // Recurse using the remaining matches and updated fragments.
             let (child_index, child_states_searched) = recurse_index_search(
@@ -375,6 +378,7 @@ pub fn index_search(
     kernel_mode: KernelMode,
     bounds: &[Bound],
     memoize: bool,
+    clique: bool,
 ) -> (u32, u32, usize) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
@@ -386,6 +390,15 @@ pub fn index_search(
 
     // Enumerate non-overlapping isomorphic subgraph pairs.
     let (_, matches) = labels_matches(mol, enumerate_mode, canonize_mode);
+
+    let graph = {
+        if clique {
+            Some(CompatGraph::new(&matches))
+        }
+        else {
+            None
+        }
+    };
 
     // Initialize the first fragment as the entire graph.
     let mut init = BitSet::new();
@@ -402,7 +415,7 @@ pub fn index_search(
     let (index, states_searched) = recurse_index_search(
         mol,
         &matches,
-        &CompatGraph::new(&matches),
+        &graph,
         subgraph,
         &[init],
         edge_count - 1,
@@ -442,6 +455,7 @@ pub fn index(mol: &Molecule) -> u32 {
         ParallelMode::DepthOne,
         KernelMode::None,
         &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
+        false,
         false,
     )
     .0

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -224,11 +224,19 @@ pub fn recurse_index_search(
     state: &[BitSet],
     state_index: usize,
     best_index: Arc<AtomicUsize>,
-    largest_remove: usize,
     bounds: &[Bound],
     parallel_mode: ParallelMode,
     kernel_mode: KernelMode,
 ) -> (usize, usize) {
+    let largest_remove = {
+        if let Some(v) = subgraph.iter().next() {
+            matches[v].0.len()
+        }
+        else {
+            return (state_index, 1);
+        }
+    };
+
     // If any bounds would prune this assembly state, halt.
     if bound_exceeded(
         mol,
@@ -306,7 +314,6 @@ pub fn recurse_index_search(
                 &fragments,
                 state_index - h1.len() + 1,
                 best_index.clone(),
-                h1.len(),
                 bounds,
                 new_parallel,
                 new_kernel,
@@ -447,7 +454,6 @@ pub fn index_search(
         &[init],
         edge_count - 1,
         best_index,
-        edge_count,
         bounds,
         parallel_mode,
         kernel_mode,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -233,6 +233,7 @@ pub fn recurse_index_search(
     if bound_exceeded(
         mol,
         matches,
+        graph,
         state,
         &subgraph,
         state_index,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use std::{
-    collections::HashMap, ops::ControlFlow, sync::{
+    collections::HashMap, sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc,
     }
@@ -221,7 +221,6 @@ pub fn recurse_index_search(
     matches: &Vec<(BitSet, BitSet)>,
     graph: &Option<CompatGraph>,
     mut subgraph: BitSet,
-    must_include: &Option<Vec<usize>>,
     state: &[BitSet],
     state_index: usize,
     best_index: Arc<AtomicUsize>,
@@ -246,7 +245,7 @@ pub fn recurse_index_search(
     }
 
     // Apply kernels
-    let mut must_include_clone = None;
+    let mut must_include = matches.len();
     if kernel_mode != KernelMode::None {
         let g = graph.as_ref().unwrap();
 
@@ -254,9 +253,7 @@ pub fn recurse_index_search(
         subgraph = deletion_kernel(matches, g, subgraph);
         
         //Inclusion kernel
-        let mut include_temp = must_include.as_ref().unwrap().clone();
-        include_temp.append(&mut inclusion_kernel(matches, g, &subgraph));
-        must_include_clone = Some(include_temp);
+        must_include = inclusion_kernel(matches, g, &subgraph);
     }
 
     // Keep track of the best assembly index found in any of this assembly
@@ -306,7 +303,6 @@ pub fn recurse_index_search(
                 matches,
                 graph,
                 sub_clone,
-                &must_include_clone,
                 &fragments,
                 state_index - h1.len() + 1,
                 best_index.clone(),
@@ -326,17 +322,10 @@ pub fn recurse_index_search(
 
     // Use the iterator type corresponding to the specified parallelism mode.
     if parallel_mode == ParallelMode::None {
-        let _ = subgraph
+        subgraph
             .iter()
-            .try_for_each(|v| {
-                recurse_on_match(v);
-                if let Some(vec) = &must_include_clone {
-                    if vec.contains(&v) {
-                        return ControlFlow::Break(());
-                    }
-                }
-                ControlFlow::Continue(())
-            });
+            .filter(|v| *v <= must_include)
+            .for_each(|v| recurse_on_match(v));
     } else {
         let _ = subgraph
             .iter()
@@ -446,15 +435,6 @@ pub fn index_search(
         subgraph.insert(i);
     }
 
-    let must_include = {
-        if kernel_mode != KernelMode::None {
-            Some(Vec::new())
-        }
-        else {
-            None
-        }
-    };
-
     // Search for the shortest assembly pathway recursively.
     let edge_count = mol.graph().edge_count();
     let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
@@ -463,7 +443,6 @@ pub fn index_search(
         &matches,
         &graph,
         subgraph,
-        &must_include,
         &[init],
         edge_count - 1,
         best_index,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -329,6 +329,7 @@ pub fn recurse_index_search(
     } else {
         let _ = subgraph
             .iter()
+            .filter(|v| *v <= must_include)
             .collect::<Vec<usize>>()
             .par_iter()
             .for_each(|v| recurse_on_match(*v));

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -204,13 +204,14 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 /// Inputs:
 /// - `mol`: The molecule whose assembly index is being calculated.
 /// - `matches`: The remaining non-overlapping isomorphic subgraph pairs.
+/// - `graph`: If clique is enabled, the graph of compatible isomorphic subgraph paris.
+/// - `subgraph`: A bitset with length of matches. Has a 1 for every match to be searched in this state.
 /// - `state`: The current assembly state, i.e., a list of fragments.
 /// - `state_index`: The assembly index of this assembly state.
 /// - `best_index`: The smallest assembly index for all assembly states so far.
-/// - `largest_remove`: An upper bound on the size of fragments that can be
-///   removed from this or any descendant assembly state.
 /// - `bounds`: The list of bounding strategies to apply.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
+/// - `kernel_mode`: The kernelization mode for this state.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: The best assembly index found.
@@ -228,6 +229,8 @@ pub fn recurse_index_search(
     parallel_mode: ParallelMode,
     kernel_mode: KernelMode,
 ) -> (usize, usize) {
+    // An upper bound on the size of fragments that can be
+    // removed from this or any descendant assembly state.
     let largest_remove = {
         if let Some(v) = subgraph.iter().next() {
             matches[v].0.len()
@@ -258,9 +261,11 @@ pub fn recurse_index_search(
         let g = graph.as_ref().unwrap();
 
         // Deletion kernel
+        // Returns a subgraph without nodes that never occur in an optimal solution.
         subgraph = deletion_kernel(matches, g, subgraph);
         
-        //Inclusion kernel
+        // Inclusion kernel.
+        // must_include is the first match in the matches list that will be included in an optimal solution.
         must_include = inclusion_kernel(matches, g, &subgraph);
     }
 
@@ -293,6 +298,8 @@ pub fn recurse_index_search(
             };
 
             // Update subgraph
+            // If using CompatGraph, only consider the neighborhood of the node removed.
+            // Otherwise, only consider the matches that occur after the removed match in the list.
             let mut sub_clone;
             if let Some(g) = graph {
                 sub_clone = subgraph.clone();
@@ -328,6 +335,8 @@ pub fn recurse_index_search(
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.
+    // Only search on nodes with v <= must_include since any searches after that would
+    // not use must_include.
     if parallel_mode == ParallelMode::None {
         subgraph
             .iter()

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -232,7 +232,9 @@ pub fn recurse_index_search(
     // If any bounds would prune this assembly state, halt.
     if bound_exceeded(
         mol,
+        matches,
         state,
+        &subgraph,
         state_index,
         best_index.load(Relaxed),
         largest_remove,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -37,6 +37,7 @@ use crate::{
     kernels::KernelMode,
     molecule::Molecule,
     utils::connected_components_under_edges,
+    reductions::CompatGraph,
 };
 
 /// Parallelization strategy for the recursive search phase.
@@ -218,7 +219,9 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 #[allow(clippy::too_many_arguments)]
 pub fn recurse_index_search(
     mol: &Molecule,
-    matches: &[(BitSet, BitSet)],
+    matches: &Vec<(BitSet, BitSet)>,
+    graph: &CompatGraph,
+    subgraph: BitSet,
     state: &[BitSet],
     state_index: usize,
     best_index: Arc<AtomicUsize>,
@@ -245,7 +248,8 @@ pub fn recurse_index_search(
 
     // Define a closure that handles recursing to a new assembly state based on
     // the given (enumerated) pair of non-overlapping isomorphic subgraphs.
-    let recurse_on_match = |i: usize, h1: &BitSet, h2: &BitSet| {
+    let recurse_on_match = |i: usize| {
+        let (h1, h2) = &matches[i];
         if let Some(fragments) = fragments(mol, state, h1, h2) {
             // If using depth-one parallelism, all descendant states should be
             // computed serially.
@@ -255,10 +259,20 @@ pub fn recurse_index_search(
                 parallel_mode
             };
 
+            // TODO: should create a method for updating subgraph
+            let mut sub_clone = subgraph.clone();
+            let mut node = subgraph.iter().next().unwrap();
+            while node <= i {
+                sub_clone.remove(node);
+                node += 1;
+            }
+
             // Recurse using the remaining matches and updated fragments.
             let (child_index, child_states_searched) = recurse_index_search(
                 mol,
-                &matches[i + 1..],
+                matches,
+                graph,
+                sub_clone,
                 &fragments,
                 state_index - h1.len() + 1,
                 best_index.clone(),
@@ -277,15 +291,15 @@ pub fn recurse_index_search(
 
     // Use the iterator type corresponding to the specified parallelism mode.
     if parallel_mode == ParallelMode::None {
-        matches
+        subgraph
             .iter()
-            .enumerate()
-            .for_each(|(i, (h1, h2))| recurse_on_match(i, h1, h2));
+            .for_each(|i| recurse_on_match(i));
     } else {
-        matches
+        subgraph
+            .iter()
+            .collect::<Vec<usize>>()
             .par_iter()
-            .enumerate()
-            .for_each(|(i, (h1, h2))| recurse_on_match(i, h1, h2));
+            .for_each(|i | recurse_on_match(*i));
     }
 
     (
@@ -377,12 +391,19 @@ pub fn index_search(
     let mut init = BitSet::new();
     init.extend(mol.graph().edge_indices().map(|ix| ix.index()));
 
+    let mut subgraph = BitSet::with_capacity(matches.len());
+    for i in 0..matches.len() {
+        subgraph.insert(i);
+    }
+
     // Search for the shortest assembly pathway recursively.
     let edge_count = mol.graph().edge_count();
     let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
     let (index, states_searched) = recurse_index_search(
         mol,
         &matches,
+        &CompatGraph::new(),
+        subgraph,
         &[init],
         edge_count - 1,
         best_index,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -34,7 +34,7 @@ use crate::{
     bounds::{bound_exceeded, Bound},
     canonize::{canonize, CanonizeMode, Labeling},
     enumerate::{enumerate_subgraphs, EnumerateMode},
-    kernels::KernelMode,
+    kernels::{KernelMode, deletion_kernel},
     molecule::Molecule,
     utils::connected_components_under_edges,
     reductions::CompatGraph,
@@ -221,13 +221,14 @@ pub fn recurse_index_search(
     mol: &Molecule,
     matches: &Vec<(BitSet, BitSet)>,
     graph: &Option<CompatGraph>,
-    subgraph: BitSet,
+    mut subgraph: BitSet,
     state: &[BitSet],
     state_index: usize,
     best_index: Arc<AtomicUsize>,
     largest_remove: usize,
     bounds: &[Bound],
     parallel_mode: ParallelMode,
+    kernel_mode: KernelMode,
 ) -> (usize, usize) {
     // If any bounds would prune this assembly state, halt.
     if bound_exceeded(
@@ -242,6 +243,12 @@ pub fn recurse_index_search(
         bounds,
     ) {
         return (state_index, 1);
+    }
+
+    // Apply kernels
+    if kernel_mode != KernelMode::None {
+        let g = graph.as_ref().unwrap();
+        subgraph = deletion_kernel(matches, g, subgraph);
     }
 
     // Keep track of the best assembly index found in any of this assembly
@@ -260,6 +267,16 @@ pub fn recurse_index_search(
                 ParallelMode::None
             } else {
                 parallel_mode
+            };
+
+            // If kernelizing once, do not kernelize again. If kernelizing at depth-one,
+            // kernelize once more at the beginning of each descendent.
+            let new_kernel = if kernel_mode == KernelMode::Once {
+                KernelMode::None
+            } else if kernel_mode == KernelMode::DepthOne {
+                KernelMode::Once
+            } else {
+                kernel_mode
             };
 
             // Update subgraph
@@ -287,6 +304,7 @@ pub fn recurse_index_search(
                 h1.len(),
                 bounds,
                 new_parallel,
+                new_kernel,
             );
 
             // Update the best assembly indices (across children states and
@@ -386,9 +404,6 @@ pub fn index_search(
     clique: bool,
 ) -> (u32, u32, usize) {
     // Catch not-yet-implemented modes.
-    if kernel_mode != KernelMode::None {
-        panic!("The chosen --kernel mode is not implemented yet!")
-    }
     if memoize {
         panic!("--memoize is not implemented yet!")
     }
@@ -428,6 +443,7 @@ pub fn index_search(
         edge_count,
         bounds,
         parallel_mode,
+        kernel_mode,
     );
 
     (index as u32, matches.len() as u32, states_searched)

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -260,11 +260,13 @@ pub fn recurse_index_search(
             };
 
             // Update subgraph
-            let mut sub_clone = BitSet::with_capacity(matches.len());
+            let mut sub_clone;
             if let Some(g) = graph {
+                sub_clone = subgraph.clone();
                 sub_clone.intersect_with(&g.forward_neighbors(v, &subgraph));
             }
             else {
+                sub_clone = BitSet::with_capacity(matches.len());
                 for j in (v+1)..matches.len() {
                     sub_clone.insert(j);
                 }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -19,11 +19,10 @@
 //! ```
 
 use std::{
-    collections::HashMap,
-    sync::{
+    collections::HashMap, ops::ControlFlow, sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc,
-    },
+    }
 };
 
 use bit_set::BitSet;
@@ -34,7 +33,7 @@ use crate::{
     bounds::{bound_exceeded, Bound},
     canonize::{canonize, CanonizeMode, Labeling},
     enumerate::{enumerate_subgraphs, EnumerateMode},
-    kernels::{KernelMode, deletion_kernel},
+    kernels::{KernelMode, deletion_kernel, inclusion_kernel},
     molecule::Molecule,
     utils::connected_components_under_edges,
     reductions::CompatGraph,
@@ -222,6 +221,7 @@ pub fn recurse_index_search(
     matches: &Vec<(BitSet, BitSet)>,
     graph: &Option<CompatGraph>,
     mut subgraph: BitSet,
+    must_include: &Option<Vec<usize>>,
     state: &[BitSet],
     state_index: usize,
     best_index: Arc<AtomicUsize>,
@@ -246,9 +246,17 @@ pub fn recurse_index_search(
     }
 
     // Apply kernels
+    let mut must_include_clone = None;
     if kernel_mode != KernelMode::None {
         let g = graph.as_ref().unwrap();
+
+        // Deletion kernel
         subgraph = deletion_kernel(matches, g, subgraph);
+        
+        //Inclusion kernel
+        let mut include_temp = must_include.as_ref().unwrap().clone();
+        include_temp.append(&mut inclusion_kernel(matches, g, &subgraph));
+        must_include_clone = Some(include_temp);
     }
 
     // Keep track of the best assembly index found in any of this assembly
@@ -298,6 +306,7 @@ pub fn recurse_index_search(
                 matches,
                 graph,
                 sub_clone,
+                &must_include_clone,
                 &fragments,
                 state_index - h1.len() + 1,
                 best_index.clone(),
@@ -317,15 +326,23 @@ pub fn recurse_index_search(
 
     // Use the iterator type corresponding to the specified parallelism mode.
     if parallel_mode == ParallelMode::None {
-        subgraph
+        let _ = subgraph
             .iter()
-            .for_each(|v| recurse_on_match(v));
+            .try_for_each(|v| {
+                recurse_on_match(v);
+                if let Some(vec) = &must_include_clone {
+                    if vec.contains(&v) {
+                        return ControlFlow::Break(());
+                    }
+                }
+                ControlFlow::Continue(())
+            });
     } else {
-        subgraph
+        let _ = subgraph
             .iter()
             .collect::<Vec<usize>>()
             .par_iter()
-            .for_each(|v | recurse_on_match(*v));
+            .for_each(|v| recurse_on_match(*v));
     }
 
     (
@@ -429,6 +446,15 @@ pub fn index_search(
         subgraph.insert(i);
     }
 
+    let must_include = {
+        if kernel_mode != KernelMode::None {
+            Some(Vec::new())
+        }
+        else {
+            None
+        }
+    };
+
     // Search for the shortest assembly pathway recursively.
     let edge_count = mol.graph().edge_count();
     let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
@@ -437,6 +463,7 @@ pub fn index_search(
         &matches,
         &graph,
         subgraph,
+        &must_include,
         &[init],
         edge_count - 1,
         best_index,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -248,8 +248,8 @@ pub fn recurse_index_search(
 
     // Define a closure that handles recursing to a new assembly state based on
     // the given (enumerated) pair of non-overlapping isomorphic subgraphs.
-    let recurse_on_match = |i: usize| {
-        let (h1, h2) = &matches[i];
+    let recurse_on_match = |v: usize| {
+        let (h1, h2) = &matches[v];
         if let Some(fragments) = fragments(mol, state, h1, h2) {
             // If using depth-one parallelism, all descendant states should be
             // computed serially.
@@ -260,12 +260,12 @@ pub fn recurse_index_search(
             };
 
             // TODO: should create a method for updating subgraph
-            let mut sub_clone = subgraph.clone();
-            let mut node = subgraph.iter().next().unwrap();
-            while node <= i {
-                sub_clone.remove(node);
-                node += 1;
-            }
+            let mut sub_clone = BitSet::with_capacity(matches.len());
+            /*let mut node = subgraph.iter().next().unwrap();
+            for j in (i+1)..matches.len() {
+                sub_clone.insert(j);
+            }*/
+            sub_clone.intersect_with(&graph.forward_neighbors(v, &subgraph));
 
             // Recurse using the remaining matches and updated fragments.
             let (child_index, child_states_searched) = recurse_index_search(
@@ -293,13 +293,13 @@ pub fn recurse_index_search(
     if parallel_mode == ParallelMode::None {
         subgraph
             .iter()
-            .for_each(|i| recurse_on_match(i));
+            .for_each(|v| recurse_on_match(v));
     } else {
         subgraph
             .iter()
             .collect::<Vec<usize>>()
             .par_iter()
-            .for_each(|i | recurse_on_match(*i));
+            .for_each(|v | recurse_on_match(*v));
     }
 
     (
@@ -402,7 +402,7 @@ pub fn index_search(
     let (index, states_searched) = recurse_index_search(
         mol,
         &matches,
-        &CompatGraph::new(),
+        &CompatGraph::new(&matches),
         subgraph,
         &[init],
         edge_count - 1,

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -73,7 +73,6 @@ pub fn deletion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, mut sub
 /// Takes a subgraph as input and returns the first vertex that will be included in some maximum weight clique.
 /// Uses the strategies of neighborhood removal and isolated vertex removal from Lamm et al.
 pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgraph: &BitSet) -> usize {
-    let mut kernel = Vec::new();
     let tot = subgraph.iter().map(|v| matches[v].0.len() - 1).sum::<usize>();
 
     'outer: for v in subgraph {
@@ -82,8 +81,7 @@ pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgra
         // Neighborhood removal
         let neighbors_val = g.neighbors(v, subgraph).iter().map(|u| matches[u].0.len() - 1).sum::<usize>();
         if v_val >= tot - neighbors_val - v_val { 
-            kernel.push(v);
-            continue;
+            return v;
         }
 
         // Isolated vertex removal.
@@ -107,13 +105,9 @@ pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgra
             neighbors.push(u);
         }
 
-        kernel.push(v);
+        return v;
     }
 
-    if let Some(x) = kernel.iter().min() {
-        *x
-    }
-    else {
-        matches.len()
-    }
+    matches.len()
+
 }

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -68,7 +68,7 @@ pub fn deletion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, mut sub
     subgraph
 }
 
-pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgraph: &BitSet) -> Vec<usize> {
+pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgraph: &BitSet) -> usize {
     let mut kernel = Vec::new();
     let tot = subgraph.iter().map(|v| matches[v].0.len() - 1).sum::<usize>();
 
@@ -102,5 +102,10 @@ pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgra
         kernel.push(v);
     }
 
-    kernel
+    if let Some(x) = kernel.iter().min() {
+        *x
+    }
+    else {
+        matches.len()
+    }
 }

--- a/src/kernels.rs
+++ b/src/kernels.rs
@@ -67,3 +67,40 @@ pub fn deletion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, mut sub
 
     subgraph
 }
+
+pub fn inclusion_kernel(matches: &Vec<(BitSet, BitSet)>, g: &CompatGraph, subgraph: &BitSet) -> Vec<usize> {
+    let mut kernel = Vec::new();
+    let tot = subgraph.iter().map(|v| matches[v].0.len() - 1).sum::<usize>();
+
+    'outer: for v in subgraph {
+        let v_val = matches[v].0.len() - 1;
+        let neighbors_val = g.neighbors(v, subgraph).iter().map(|u| matches[u].0.len() - 1).sum::<usize>();
+        if v_val >= tot - neighbors_val - v_val { 
+            kernel.push(v);
+            continue;
+        }
+
+        let mut neighbors: Vec<usize> = vec![];
+
+        for u in subgraph.difference(&g.compatible_with(v)) {
+            if u == v {
+                continue;
+            }
+            if matches[u].0.len() - 1 > v_val {
+                continue 'outer;
+            }
+
+            for w in neighbors.iter() {
+                if g.are_adjacent(u, *w) {
+                    continue 'outer;
+                }   
+            }
+
+            neighbors.push(u);
+        }
+
+        kernel.push(v);
+    }
+
+    kernel
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod bounds;
 pub mod canonize;
 pub mod enumerate;
 pub mod kernels;
+pub mod reductions;
 mod vf3;
 
 // Python wrapper.

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ struct Cli {
     /// Strategy for performing graph kernelization during the search phase.
     #[arg(long, value_enum, default_value_t = KernelMode::None)]
     kernel: KernelMode,
+
+    #[arg(long)]
+    clique: bool,
 }
 
 #[derive(Args, Debug)]
@@ -115,6 +118,7 @@ fn main() -> Result<()> {
         cli.kernel,
         boundlist,
         cli.memoize,
+        cli.clique,
     );
 
     // Print final output, depending on --verbose.

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,9 @@ fn main() -> Result<()> {
         if !cli.clique && boundlist.contains(&bound) {
             panic!("Bound {:?} can not be used without clique enabled", bound);
         }
+        if !cli.clique && cli.kernel != KernelMode::None {
+            panic!("Cannot use kernels without clique enabled");
+        }
     }
 
     // Call index calculation with all the various options.

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,19 +95,28 @@ fn main() -> Result<()> {
     }
 
     // Handle bounding strategy CLI arguments.
-    let boundlist: &[Bound] = match cli.boundsgroup {
-        // By default, use a combination of the integer and vector bounds.
-        None => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
+    let boundlist: &[Bound] = match (cli.boundsgroup, cli.clique) {
+        // If clique not enable, default to a combination of the integer and vector bounds.
+        (None, false) => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
+        // If clique is enabled, default to combination of int, vec, and clique bounds.
+        (None, true) => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags, Bound::CliqueBudget],
         // If --no-bounds is set, do not use any bounds.
-        Some(BoundsGroup {
+        (Some(BoundsGroup {
             no_bounds: true, ..
-        }) => &[],
+        }), _) => &[],
         // Otherwise, use the bounds that were specified.
-        Some(BoundsGroup {
+        (Some(BoundsGroup {
             no_bounds: false,
             bounds,
-        }) => &bounds.clone(),
+        }), _) => &bounds.clone(),
     };
+
+    let clique_bounds = vec![Bound::CliqueBudget, Bound::CoverNoSort, Bound::CoverSort];
+    for bound in clique_bounds {
+        if !cli.clique && boundlist.contains(&bound) {
+            panic!("Bound {:?} can not be used without clique enabled", bound);
+        }
+    }
 
     // Call index calculation with all the various options.
     let (index, num_matches, states_searched) = index_search(

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
         // If clique not enable, default to a combination of the integer and vector bounds.
         (None, false) => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags],
         // If clique is enabled, default to combination of int, vec, and clique bounds.
-        (None, true) => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags, Bound::CliqueBudget],
+        (None, true) => &[Bound::Int, Bound::VecSimple, Bound::VecSmallFrags, Bound::CliqueBudget, Bound::CoverNoSort],
         // If --no-bounds is set, do not use any bounds.
         (Some(BoundsGroup {
             no_bounds: true, ..

--- a/src/python.rs
+++ b/src/python.rs
@@ -437,6 +437,8 @@ pub fn _index_search(
         kernel_mode,
         &boundlist,
         memoize,
+        // TODO: implement clique CLI param for python interface
+        false,
     ))
 }
 

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -2,26 +2,16 @@ use bit_set::BitSet;
 
 pub struct CompatGraph {
     graph: Vec<BitSet>,
-    nodes: Vec<usize>,
 }
 
 impl CompatGraph {
-    pub fn new () -> Self {
-        Self {
-            graph: Vec::new(),
-            nodes: Vec::new(),
-        }
-    }
-
-    /*pub fn new(init_matches: Vec<(BitSet, BitSet)>) -> Self {
+    pub fn new(init_matches: &Vec<(BitSet, BitSet)>) -> Self {
         let size = init_matches.len();
 
         // Initialize weights and empty graph
         let mut init_graph: Vec<BitSet> = Vec::with_capacity(size);
-        let mut init_weights: Vec<usize> = Vec::with_capacity(size);
         for m in init_matches.iter() {
             init_graph.push(BitSet::with_capacity(size));
-            init_weights.push(m.0.len() - 1);
         }
 
         // Populate graph
@@ -45,18 +35,16 @@ impl CompatGraph {
 
         Self {
             graph: init_graph,
-            weights: init_weights,
-            matches: init_matches,
         }
     }
 
-    pub fn weight(&self, v: usize) -> usize {
+    /*pub fn weight(&self, v: usize) -> usize {
         self.weights[v]
     }
 
     pub fn matches(&self, v: usize) -> &(BitSet, BitSet) {
         &self.matches[v]
-    }
+    }*/
 
     pub fn len(&self) -> usize {
         self.graph.len()
@@ -98,5 +86,5 @@ impl CompatGraph {
 
     pub fn are_adjacent(&self, v: usize, u: usize) -> bool {
         self.graph[v].contains(u)
-    }*/
+    }
 }

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -38,14 +38,6 @@ impl CompatGraph {
         }
     }
 
-    /*pub fn weight(&self, v: usize) -> usize {
-        self.weights[v]
-    }
-
-    pub fn matches(&self, v: usize) -> &(BitSet, BitSet) {
-        &self.matches[v]
-    }*/
-
     pub fn len(&self) -> usize {
         self.graph.len()
     }

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -10,7 +10,7 @@ impl CompatGraph {
 
         // Initialize weights and empty graph
         let mut init_graph: Vec<BitSet> = Vec::with_capacity(size);
-        for m in init_matches.iter() {
+        for _ in 0..init_matches.len() {
             init_graph.push(BitSet::with_capacity(size));
         }
 

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -1,0 +1,96 @@
+use bit_set::BitSet;
+
+pub struct CompatGraph {
+    graph: Vec<BitSet>,
+    weights: Vec<usize>,
+    matches: Vec<(BitSet, BitSet)>
+}
+
+impl CompatGraph {
+    pub fn new(init_matches: Vec<(BitSet, BitSet)>) -> Self {
+        let size = init_matches.len();
+
+        // Initialize weights and empty graph
+        let mut init_graph: Vec<BitSet> = Vec::with_capacity(size);
+        let mut init_weights: Vec<usize> = Vec::with_capacity(size);
+        for m in init_matches.iter() {
+            init_graph.push(BitSet::with_capacity(size));
+            init_weights.push(m.0.len() - 1);
+        }
+
+        // Populate graph
+        for (idx1, (h1, h2)) in init_matches.iter().enumerate() {
+            for (idx2, (h1p, h2p)) in init_matches[idx1 + 1..].iter().enumerate() {
+                let idx2 = idx2 + idx1 + 1;
+
+                let forward_compatible = {
+                    h2.is_disjoint(h1p) && 
+                    h2.is_disjoint(h2p) &&
+                    (h1.is_disjoint(h1p) || h1.is_superset(h1p)) &&
+                    (h1.is_disjoint(h2p) || h1.is_superset(h2p))
+                };
+
+                if forward_compatible {
+                    init_graph[idx1].insert(idx2);
+                    init_graph[idx2].insert(idx1);
+                }
+            }
+        }
+
+        Self {
+            graph: init_graph,
+            weights: init_weights,
+            matches: init_matches,
+        }
+    }
+
+    pub fn weight(&self, v: usize) -> usize {
+        self.weights[v]
+    }
+
+    pub fn matches(&self, v: usize) -> &(BitSet, BitSet) {
+        &self.matches[v]
+    }
+
+    pub fn len(&self) -> usize {
+        self.graph.len()
+    }
+
+    pub fn degree(&self, v: usize, subgraph: &BitSet) -> usize {
+        self.graph[v].intersection(subgraph).count()
+    }
+
+    pub fn compatible_with(&self, v: usize) -> &BitSet {
+        &self.graph[v]
+    }
+
+    pub fn neighbors(&self, v: usize, subgraph: &BitSet) -> BitSet {
+        let mut neighbors = self.graph[v].clone();
+        neighbors.intersect_with(subgraph);
+        
+        neighbors
+    }
+
+    pub fn forward_neighbors(&self, v: usize, subgraph: &BitSet) -> BitSet {
+        let mut neighbors = self.graph[v].clone();
+        neighbors.intersect_with(subgraph);
+        let mut to_remove = vec![];
+        for u in neighbors.iter() {
+            if u <= v {
+                to_remove.push(u);
+            }
+            if u > v {
+                break;
+            }
+        }
+        for u in to_remove {
+            neighbors.remove(u);
+        }
+
+        neighbors
+    }
+
+    pub fn are_adjacent(&self, v: usize, u: usize) -> bool {
+        self.graph[v].contains(u)
+    }
+}

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -2,12 +2,18 @@ use bit_set::BitSet;
 
 pub struct CompatGraph {
     graph: Vec<BitSet>,
-    weights: Vec<usize>,
-    matches: Vec<(BitSet, BitSet)>
+    nodes: Vec<usize>,
 }
 
 impl CompatGraph {
-    pub fn new(init_matches: Vec<(BitSet, BitSet)>) -> Self {
+    pub fn new () -> Self {
+        Self {
+            graph: Vec::new(),
+            nodes: Vec::new(),
+        }
+    }
+
+    /*pub fn new(init_matches: Vec<(BitSet, BitSet)>) -> Self {
         let size = init_matches.len();
 
         // Initialize weights and empty graph
@@ -92,5 +98,5 @@ impl CompatGraph {
 
     pub fn are_adjacent(&self, v: usize, u: usize) -> bool {
         self.graph[v].contains(u)
-    }
+    }*/
 }

--- a/src/reductions.rs
+++ b/src/reductions.rs
@@ -1,10 +1,25 @@
+//! Reduces the optimal molecular assembly index problem into maximum weighted clique.
+//! 
+//! Removing a duplicatable subgraph pair (h1, h2) gives a savings of |h1| - 1.
+//! The problem of finding the optimal molecular assembly index can thus be thought of as finding
+//! a set of duplicatable subgraph removals that are all compatible with each other (i.e. can be removed
+//! at the same time) with the largest savings possible. Thus, this problem is close to that of finding
+//! a maximum clique in a graph with duplicatable subgraph pairs for vertices, vertex weights |h1| - 1, and
+//! edges representing compatibility. However, the order of duplicatable subgraph removals can affect
+//! compatibility, and so edges must be directed. By ordering the vertices in a nice way, we can ignore
+//! edge directionality.
+
 use bit_set::BitSet;
 
+/// Graph representation of the compatibility of duplicatable subgraph pairs.
 pub struct CompatGraph {
+    /// The graph is implemented as an adjacency matrix. The ith element of graph
+    /// has a 1 at position j if {i, j} is an edge.
     graph: Vec<BitSet>,
 }
 
 impl CompatGraph {
+    /// Constructs a compatibility graph given a set of matches.
     pub fn new(init_matches: &Vec<(BitSet, BitSet)>) -> Self {
         let size = init_matches.len();
 
@@ -38,18 +53,25 @@ impl CompatGraph {
         }
     }
 
+    /// Returns the number of vertices in the graph.
     pub fn len(&self) -> usize {
         self.graph.len()
     }
 
+    /// Returns the degree vertex v in the subgraph
     pub fn degree(&self, v: usize, subgraph: &BitSet) -> usize {
         self.graph[v].intersection(subgraph).count()
     }
 
+    /// Returns the set of matches compatible with v. I.e. the set neighbors
+    /// of v.
     pub fn compatible_with(&self, v: usize) -> &BitSet {
         &self.graph[v]
     }
 
+    /// Returns the neighbors of v in the given subgraph.
+    /// The returned BitSet is a clone, and thus can be safely modified by the calling function
+    /// without changing the graph.
     pub fn neighbors(&self, v: usize, subgraph: &BitSet) -> BitSet {
         let mut neighbors = self.graph[v].clone();
         neighbors.intersect_with(subgraph);
@@ -57,6 +79,9 @@ impl CompatGraph {
         neighbors
     }
 
+    /// Returns the neighbors of v that occur after v in the matches list.
+    /// The returned BitSet is a clone, and thus can be safely modified by the calling function
+    /// without changing the graph.
     pub fn forward_neighbors(&self, v: usize, subgraph: &BitSet) -> BitSet {
         let mut neighbors = self.graph[v].clone();
         neighbors.intersect_with(subgraph);
@@ -76,6 +101,7 @@ impl CompatGraph {
         neighbors
     }
 
+    /// Returns true if vertices v and u are adjacent.
     pub fn are_adjacent(&self, v: usize, u: usize) -> bool {
         self.graph[v].contains(u)
     }


### PR DESCRIPTION
- The file `reductions.rs` has been added. At the moment includes only the reduction to maximum weighted clique.
  - Add the struct `CompatGraph` to hold the graph of the max weight clique problem. Weights are not stored as part of the struct, and instead are calculated from `matches` when needed.
  - `CompatGraph` currently uses a adjacency matrix representation, implemented as `Vec<BitSet>`.
- `recurse_index_search` now uses a bitset `subgraph` to represent what matches to search next, instead of slicing the matches list.
  - This structure can be used both when the `CompatGraph` is used or not used.
- Adds new CLI parameter `--clique`, which when enabled builds and uses the `CompatGraph` for searching.
  - If kernels or bounds using `CompatGraph` are turned on without `--clique` also turned on, the program will panic.
- Added new bounds to be used when `--clique` is enabled.
  - `CliqueBudget` uses the `CompatGraph` to determine what duplicates can be removed from each fragment. This information can be used to get a quick estimate of the best possible removals for each fragment.
  - `CoverBoundNoSort` and `CoverBoundSort` find an independent set cover in the graph, which can be used to bound the max weight clique. Using `CoverBoundSort` first sorts the vertices in decreasing order of degree.
- Added functions `deletion_kernel` and `inclusion_kernel` to `kernels.rs`.
  - Kernel methods taken from Lamm et al. 2019. https://doi.org/10.1137/1.9781611975499.12  
  - Deletion kernel looks for dominating vertices and removes matches from consideration.
  - Inclusion kernel looks for vertices using the neighborhood removal and isolated vertex removal methods. Finds vertices that must be included as part of some max weight clique.