### PR TITLE
Set default parameters and fix bound ordering in Python index_search 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,7 +54,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install assembly-theory --find-links dist --force-reinstall
+          pip install assembly-theory --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 
@@ -97,7 +97,7 @@ jobs:
             pip3 install -U pip pytest
           run: |
             set -e
-            pip3 install assembly-theory --find-links dist --force-reinstall
+            pip3 install assembly-theory --no-index --find-links dist --force-reinstall
             pytest
 
   macos:
@@ -134,7 +134,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install assembly-theory --find-links dist --force-reinstall
+          pip install assembly-theory --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 

--- a/python/tests/test_assembly_theory.py
+++ b/python/tests/test_assembly_theory.py
@@ -71,7 +71,7 @@ def test_index_search():
             "none",  # Disable parallelism for deterministic states_searched.
             "none",
             "none",
-            set(["int", "vec-simple", "vec-small-frags"]))
+            ["int", "vec-simple", "vec-small-frags"])
 
     assert (index, num_matches, states_searched) == (6, 466, 2562)
 
@@ -84,7 +84,7 @@ def test_index_search_bad_molblock():
                         "none",
                         "none",
                         "none",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is OSError
 
@@ -100,7 +100,7 @@ def test_index_search_bad_enumerate():
                         "none",
                         "none",
                         "none",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is ValueError and "Invalid enumeration" in str(e.value)
 
@@ -116,7 +116,7 @@ def test_index_search_bad_canonize():
                         "none",
                         "none",
                         "none",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is ValueError and "Invalid canonization" in str(e.value)
 
@@ -132,7 +132,7 @@ def test_index_search_bad_parallel():
                         "invalid-mode",
                         "none",
                         "none",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is ValueError and "Invalid parallelization" in str(e.value)
 
@@ -148,7 +148,7 @@ def test_index_search_bad_memoize():
                         "none",
                         "invalid-mode",
                         "none",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is ValueError and "Invalid memoization" in str(e.value)
 
@@ -164,7 +164,7 @@ def test_index_search_bad_kernel():
                         "none",
                         "none",
                         "invalid-mode",
-                        set(["int", "vec-simple", "vec-small-frags"]))
+                        ["int", "vec-simple", "vec-small-frags"])
 
     assert e.type is ValueError and "Invalid kernelization" in str(e.value)
 
@@ -180,6 +180,6 @@ def test_index_search_bad_bound():
                         "none",
                         "none",
                         "none",
-                        set(["int", "invalid-bound"]))
+                        ["int", "invalid-bound"])
 
     assert e.type is ValueError and "Invalid bound" in str(e.value)

--- a/python/tests/test_assembly_theory.py
+++ b/python/tests/test_assembly_theory.py
@@ -78,13 +78,7 @@ def test_index_search():
 
 def test_index_search_bad_molblock():
     with pytest.raises(OSError) as e:
-        at.index_search("This string is not the contents of a .mol file.",
-                        "grow-erode",
-                        "tree-nauty",
-                        "none",
-                        "none",
-                        "none",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search("This string is not the contents of a .mol file.")
 
     assert e.type is OSError
 
@@ -94,13 +88,7 @@ def test_index_search_bad_enumerate():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "invalid-mode",
-                        "tree-nauty",
-                        "none",
-                        "none",
-                        "none",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search(mol_block, enumerate_str="invalid-mode")
 
     assert e.type is ValueError and "Invalid enumeration" in str(e.value)
 
@@ -110,13 +98,7 @@ def test_index_search_bad_canonize():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "grow-erode",
-                        "invalid-mode",
-                        "none",
-                        "none",
-                        "none",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search(mol_block, canonize_str="invalid-mode")
 
     assert e.type is ValueError and "Invalid canonization" in str(e.value)
 
@@ -126,13 +108,7 @@ def test_index_search_bad_parallel():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "grow-erode",
-                        "tree-nauty",
-                        "invalid-mode",
-                        "none",
-                        "none",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search(mol_block, parallel_str="invalid-mode")
 
     assert e.type is ValueError and "Invalid parallelization" in str(e.value)
 
@@ -142,13 +118,7 @@ def test_index_search_bad_memoize():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "grow-erode",
-                        "tree-nauty",
-                        "none",
-                        "invalid-mode",
-                        "none",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search(mol_block, memoize_str="invalid-mode")
 
     assert e.type is ValueError and "Invalid memoization" in str(e.value)
 
@@ -158,13 +128,7 @@ def test_index_search_bad_kernel():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "grow-erode",
-                        "tree-nauty",
-                        "none",
-                        "none",
-                        "invalid-mode",
-                        ["int", "vec-simple", "vec-small-frags"])
+        at.index_search(mol_block, kernel_str="invalid-mode")
 
     assert e.type is ValueError and "Invalid kernelization" in str(e.value)
 
@@ -174,12 +138,6 @@ def test_index_search_bad_bound():
         mol_block = f.read()
 
     with pytest.raises(ValueError) as e:
-        at.index_search(mol_block,
-                        "grow-erode",
-                        "tree-nauty",
-                        "none",
-                        "none",
-                        "none",
-                        ["int", "invalid-bound"])
+        at.index_search(mol_block, bound_strs=["int", "invalid-bound"])
 
     assert e.type is ValueError and "Invalid bound" in str(e.value)

--- a/src/python.rs
+++ b/src/python.rs
@@ -23,7 +23,7 @@
 //! at.index(mol_block)  # 6
 //! ```
 
-use std::{collections::HashSet, str::FromStr};
+use std::str::FromStr;
 
 use pyo3::{
     exceptions::{PyOSError, PyValueError},
@@ -212,9 +212,9 @@ impl FromStr for PyBound {
     }
 }
 
-/// Converts a `HashSet<String>` of bound strings from Python into a
-/// `Vec<PyBound>`, raising an error if any bound string is invalid.
-fn process_bound_strs(bound_strs: HashSet<String>) -> PyResult<Vec<PyBound>> {
+/// Converts a `Vec<String>` of bound Python strings into a `Vec<PyBound>`,
+/// raising an error if any bound string is invalid.
+fn process_bound_strs(bound_strs: Vec<String>) -> PyResult<Vec<PyBound>> {
     bound_strs
         .iter()
         .map(|s| s.parse())
@@ -374,7 +374,7 @@ pub fn _index(mol_block: String) -> PyResult<u32> {
 /// `canon-index`]. See [`MemoizeMode`] for details.
 /// - `kernel_str`: A kernelization mode from [`"none"`, `"once"`,
 /// `"depth-one"`, `"always"`]. See [`KernelMode`] for details.
-/// - `bound_strs`: A `set` of bounds containing zero or more of [`"log"`,
+/// - `bound_strs`: A list of bounds containing zero or more of [`"log"`,
 /// `"int"`, `"vec-simple"`, `"vec-small-frags"`, `"cover-sort"`,
 /// `"cover-no-sort"`, `"clique-budget"`]. See [`crate::bounds::Bound`] for
 /// details.
@@ -403,7 +403,7 @@ pub fn _index(mol_block: String) -> PyResult<u32> {
 ///     "none",
 ///     "none",
 ///     "none",
-///     set(["int", "vec-simple", "vec-small-frags"]))
+///     ["int", "vec-simple", "vec-small-frags"])
 ///
 /// print(f"Assembly Index: {index}")  # 6
 /// print(f"Non-Overlapping Isomorphic Subgraph Pairs: {num_matches}")  # 466
@@ -417,7 +417,7 @@ pub fn _index_search(
     parallel_str: String,
     memoize_str: String,
     kernel_str: String,
-    bound_strs: HashSet<String>,
+    bound_strs: Vec<String>,
 ) -> PyResult<(u32, u32, usize)> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol_result = parse_molfile_str(&mol_block);


### PR DESCRIPTION
Fixes #113 and resolves #114. Specifically, the Python version of `index_search` now:

- Respects the order of bound strings provided as its `bound_strs` parameter.
- Sets default parameter values equivalent to what is considered default in the CLI and in the `index` function, which can be overridden as needed.

The documentation and Python tests are updated accordingly.