### PR TITLE
Add shields to repository README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # assembly-theory
 
+[![crates.io](https://img.shields.io/crates/v/assembly-theory)](https://crates.io/crates/assembly-theory)
+[![PyPI](https://img.shields.io/pypi/v/assembly-theory)](https://pypi.org/project/assembly-theory/)
+[![docs.rs](https://docs.rs/assembly-theory/badge.svg)](https://docs.rs/assembly-theory)
+[![Zenodo](https://zenodo.org/badge/DOI/10.5281/zenodo.16764413.svg)](https://doi.org/10.5281/zenodo.16764413)
+
 `assembly-theory` is an open-source, high-performance library for computing *assembly indices* of molecular structures (see, e.g., [Sharma et al., 2023](https://doi.org/10.1038/s41586-023-06600-9); [Walker et al., 2024](https://doi.org/10.1098/rsif.2024.0367)).
 It is implemented in Rust and is available as a [Rust crate](https://crates.io/crates/assembly-theory), [Python package](https://pypi.org/project/assembly-theory/), and standalone executable. 
 


### PR DESCRIPTION
Adds visual "shields" for crates.io, PyPI, docs.rs, and Zenodo to the top of the repository README.