### PR TITLE
Promote Garrett Parzych to maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ Want to contribute your own code?
 External contributors should work in repository forks.
 - Commit messages should follow [conventional commits](https://www.conventionalcommits.org).
 - Before opening a pull request onto `main`, make sure you rebase onto `main`, run `cargo fmt`, and resolve any issues raised by `cargo clippy`.
-- Open a [new pull request](https://github.com/DaymudeLab/assembly-theory/compare), provide a descriptive list of your changes (with references to any issues your PR resolves), and assign one of [@AgentElement](https://github.com/AgentElement), [@jdaymude](https://github.com/jdaymude), or [@colemathis](https://github.com/colemathis) as a reviewer. 
+- Open a [new pull request](https://github.com/DaymudeLab/assembly-theory/compare), provide a descriptive list of your changes (with references to any issues your PR resolves), and assign one of [@AgentElement](https://github.com/AgentElement), [@Garrett-Pz](https://github.com/Garrett-Pz), [@jdaymude](https://github.com/jdaymude), or [@colemathis](https://github.com/colemathis) as a reviewer. 
 Your PR will not be reviewed unless it passes all GitHub Actions (compilation, formatting, tests, etc.).
 
 
 ## Governance
 
-`assembly-theory` is maintained by Devansh Vimal ([@AgentElement](https://github.com/AgentElement)), Joshua J. Daymude ([@jdaymude](https://github.com/jdaymude)), and Cole Mathis ([@colemathis](https://github.com/colemathis)) with support from other members of the [Biodesign Center for Biocomputing, Security and Society](https://biodesign.asu.edu/biocomputing-security-and-society/) at Arizona State University including Garrett Parzych ([@Garrett-Pz](https://github.com/Garrett-Pz)), Olivia M. Smith ([@omsmith161](https://github.com/omsmith161)), Devendra Parkar ([@devrz45](https://github.com/devrz45)), and Sean Bergen ([@ARandomCl0wn](https://github.com/ARandomCl0wn)).
+`assembly-theory` is maintained by Devansh Vimal ([@AgentElement](https://github.com/AgentElement)), Garrett Parzych ([@Garrett-Pz](https://github.com/Garrett-Pz)), Joshua J. Daymude ([@jdaymude](https://github.com/jdaymude)), and Cole Mathis ([@colemathis](https://github.com/colemathis)) with support from other members of the [Biodesign Center for Biocomputing, Security and Society](https://biodesign.asu.edu/biocomputing-security-and-society/) at Arizona State University including Olivia M. Smith ([@omsmith161](https://github.com/omsmith161)), Devendra Parkar ([@devrz45](https://github.com/devrz45)), and Sean Bergen ([@ARandomCl0wn](https://github.com/ARandomCl0wn)).
 
 The maintainers govern the project using the committee model: high-level decisions about the project's direction require maintainer consensus, major code changes require majority approval, hotfixes and patches require just one maintainer approval, new maintainers can be added by unanimous decision of the existing maintainers, and existing maintainers can step down with advance notice.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,15 @@ readme = "python/README.md"
 requires-python = ">=3.10"
 authors = [
   {name = "Devansh Vimal", email = "dvpatel5@asu.edu"},
-  {name = "Cole Mathis", email = "cole.mathis@asu.edu"},
+  {name = "Garrett Parzych", email = "gparzych@asu.edu"},
   {name = "Joshua Daymude", email = "jdaymude@asu.edu"},
+  {name = "Cole Mathis", email = "cole.mathis@asu.edu"},
 ]
 maintainers = [
   {name = "Devansh Vimal", email = "dvpatel5@asu.edu"},
-  {name = "Cole Mathis", email = "cole.mathis@asu.edu"},
+  {name = "Garrett Parzych", email = "gparzych@asu.edu"},
   {name = "Joshua Daymude", email = "jdaymude@asu.edu"},
+  {name = "Cole Mathis", email = "cole.mathis@asu.edu"},
 ]
 
 [project.urls]


### PR DESCRIPTION
@Garrett-Pz has implemented much of our codebase alongside @AgentElement and is now responsible for many of the novel algorithmic improvements. I would like to officially make him a maintainer of the project.

According to our governance statement:

> new maintainers can be added by unanimous decision of the existing maintainers

So I am requesting reviews from both @colemathis and @AgentElement, with my approval implicit in this PR.