### PR TITLE
Change parallel iterator to ParallelBridge

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -25,7 +25,7 @@ use std::sync::{
 
 use bit_set::BitSet;
 use clap::ValueEnum;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{ParallelBridge, ParallelIterator};
 
 use crate::{
     bounds::{state_bounds, Bound},
@@ -222,8 +222,9 @@ pub fn recurse_index_search(
             .for_each(|(i, match_ix)| recurse_on_match(i, *match_ix));
     } else {
         matches_to_remove
-            .par_iter()
+            .iter()
             .enumerate()
+            .par_bridge()
             .for_each(|(i, match_ix)| recurse_on_match(i, *match_ix));
     }
 


### PR DESCRIPTION
Changes the iterator in `assembly::recurse_index_search` from a [`rayon::iter::IndexedParallelIterator`](https://docs.rs/rayon/latest/rayon/iter/trait.IndexedParallelIterator.html) to a [`rayon::iter::ParallelBridge`](https://docs.rs/rayon/latest/rayon/iter/trait.ParallelBridge.html).

The memoization cache's performance is sensitive to ordering, with earlier assembly states in the search tree having precedence, so in general it is better to visit states in as close to the serial order as possible. An `IndexedParallelIterator` splits a standard iterator into pieces, then passes these pieces to the threads. With this method, there are often threads working on disparate parts of the search tree, leading to poorer cache performance. A `ParallelBridge`, on the other hand, provides the next element of a standard iterator sequentially to threads as they are available. This more closely follows the serial ordering, and can offer a performance boost.