### PR TITLE
Update deprecated macOS 13 GitHub Actions runner

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -105,9 +105,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
+            target: aarch64
+          - runner: macos-latest
             target: aarch64
     steps:
       - uses: actions/checkout@v4
@@ -127,7 +127,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.platform.target }}
+          name: wheels-${{ matrix.platform.runner }}-${{ matrix.platform.target }}
           path: dist
       - name: pytest
         run: |


### PR DESCRIPTION
As explained in https://github.com/actions/runner-images/issues/13046, the `macos-13` runner is now deprecated. This PR replaces it with the `macos-latest` runner, which currently resolves to macOS 15.