### PR TITLE
Implement algorithm from Seet et al. for pathway reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ A full list of options for returning more information or customizing the assembl
 ./target/release/assembly-theory --help
 ```
 
+To extract and print the assembly pathway (the step-by-step reconstruction of the molecule from its basic fragments), use the `--extract-pathway` flag:
+
+```shell
+./target/release/assembly-theory data/checks/anthracene.mol --extract-pathway
+```
+
 
 ### Tests and Benchmarks
 
@@ -115,6 +121,16 @@ anthracene = Chem.MolToMolBlock(anthracene)
 
 # Calculate the molecule's assembly index.
 at.index(anthracene)  # 6
+```
+
+You can also extract the full assembly pathway, showing how the molecule is built from its fragments:
+
+```python
+# Extract the assembly pathway.
+(index, num_matches, states_searched, pathway) = at.pathway_search(anthracene)
+
+for step in pathway:
+    print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
 ```
 
 See the [`assembly_theory::python` documentation](https://docs.rs/assembly-theory/latest/assembly_theory/python) for a complete list of functions exposed to the Python package along with usage examples.

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -126,6 +126,8 @@ pub fn bench_bounds(c: &mut Criterion) {
                                     bounds,
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    None,
+                                    &[],
                                 );
                                 total_time += start.elapsed();
                             }
@@ -190,6 +192,8 @@ pub fn bench_memoize(c: &mut Criterion) {
                                     &[Bound::Int, Bound::MatchableEdges],
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    None,
+                                    &[],
                                 );
                                 total_time += start.elapsed();
                             }

--- a/python/README.md
+++ b/python/README.md
@@ -68,6 +68,17 @@ M  END"""
 
 # Calculate the molecule's assembly index.
 at.index(mol_block)  # 6
+
+# Calculate the assembly index and extract the construction pathway.
+result = at.pathway_search(mol_block)
+# result is a 4-tuple: (assembly_index, num_duplicates, num_remnant_edges, pathway)
+# pathway is a list of PathwayStep dicts, each with keys:
+#   "piece_a", "piece_b", "result" — lists of bond indices describing
+#   how two fragments join to form a larger one.
+ai, num_dups, num_remnants, pathway = result
+print(f"Assembly index: {ai}")
+for step in pathway:
+    print(f"  Join bonds {step['piece_a']} + {step['piece_b']} -> {step['result']}")
 ```
 
 Combine `assembly-theory` with [RDKit](https://pypi.org/project/rdkit-pypi/) (installed separately) if you need to manipulate molecular representations or incorporate assembly index calculations in a broader cheminformatics pipeline.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,3 +68,15 @@ Calculate assembly indices using:
 Both [`assembly_go`](https://github.com/croningp/assembly_go) and [`assemblycpp-v5`](https://github.com/croningp/assemblycpp-v5) are open-source software for calculating assembly indices.
 We do not package their source code or executables with our library, but they can be obtained from GitHub if non-self-referential ground truth is desired.
 Otherwise, a release build of `assembly-theory` is created and used.
+
+
+### `compare_pathways.sh`
+
+Compares the assembly pathway output of the Rust `assembly-theory` binary (`--extract-pathway`) against the C++ `assemblycpp-v5` binary across all molecules in `data/checks/`.
+Validates that the assembly index, number of duplicates, duplicate sizes, and remnant edge count agree between both implementations.
+
+Expects the [`assemblycpp-v5`](https://github.com/croningp/assemblycpp-v5) repository to be checked out alongside this repository (i.e., at `../../assemblycpp-v5` relative to this script).
+
+```shell
+zsh compare_pathways.sh
+```

--- a/scripts/compare_pathways.sh
+++ b/scripts/compare_pathways.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env zsh
+# =============================================================================
+# Compare assembly pathway outputs between Rust and C++ implementations.
+#
+# BACKGROUND
+# ----------
+# Both codebases compute a molecule's assembly index by finding pairs of
+# edge-disjoint isomorphic subgraphs ("duplicates") in a top-down search.
+# The assembly index = total_edges - 1 - sum(dup_sizes - 1).
+#
+# OUTPUT FORMATS
+# --------------
+# Rust (--extract-pathway):
+#   Prints a bottom-up pathway (explicit join steps) and a decomposition
+#   summary with duplicate pairs as vertex-pair edge lists.
+#   "Remnant edges" = total_edges - sum(duplicate Right sizes)
+#     i.e., all edges not accounted for by duplicate removal.
+#
+# C++ (writes <name>Pathway JSON):
+#   Outputs the molecule graph, a "remnant" subgraph, a "duplicates" list,
+#   and a "removed_edges" list.
+#   The C++ preprocesses the molecule BEFORE search: edges whose chemical
+#   signature (atom_type + bond_type + atom_type) appears only once in the
+#   molecule are stripped as "removed_edges" — they can never be part of a
+#   duplicate pair. The C++ "remnant" only contains the remaining edges.
+#   So: C++ remnant + len(removed_edges) = Rust remnant.
+#
+# WHAT THIS SCRIPT COMPARES
+# -------------------------
+# For each .mol file in data/checks/, runs both implementations and compares:
+#   1. Assembly index (should be identical)
+#   2. Number of duplicate pairs (should be identical)
+#   3. Duplicate sizes, sorted descending (should be identical)
+#   4. Remnant edge count: Rust remnant vs C++ (remnant + removed_edges)
+#      These should match because both equal total_edges - sum(dup sizes).
+#
+# The specific edges in the remnant/duplicates may differ between runs (the
+# search is nondeterministic due to parallelism and HashMap ordering), but the
+# structural invariants above must always agree.
+#
+# NOTES
+# -----
+# - The C++ binary expects input WITHOUT .mol extension; it appends .mol
+#   internally. It also requires the .mol file in the current directory.
+# - Some molecules (morphine, cyanidin) may take minutes in the C++ binary.
+# - Expects assemblycpp-v5 to be checked out alongside this repository
+#   (i.e., at ../../assemblycpp-v5 relative to this script).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+RUST_DIR="$SCRIPT_DIR/.."
+CPP_DIR="$SCRIPT_DIR/../../assemblycpp-v5"
+RUST_BIN="$RUST_DIR/target/debug/assembly-theory"
+CPP_BIN="$CPP_DIR/build/bin/assembly"
+MOL_DIR="$RUST_DIR/data/checks"
+WORK_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Build Rust binary if needed.
+if [[ ! -x "$RUST_BIN" ]]; then
+    echo "Building Rust binary..."
+    (cd "$RUST_DIR" && cargo build)
+fi
+
+# Check C++ binary exists.
+if [[ ! -x "$CPP_BIN" ]]; then
+    echo "ERROR: C++ binary not found at $CPP_BIN"
+    echo "Build it first: cd $CPP_DIR/build && cmake .. && make"
+    exit 1
+fi
+
+pass=0
+fail=0
+errors=()
+
+for molfile in "$MOL_DIR"/*.mol; do
+    molname="${molfile:t:r}"  # basename without extension
+    echo -n "Testing $molname ... "
+
+    # --- Rust ---
+    rust_output=$("$RUST_BIN" --extract-pathway "$molfile" 2>&1)
+    rust_index=$(echo "$rust_output" | head -1)
+    rust_dups=$(echo "$rust_output" | grep "Duplicates:" | sed 's/.*Duplicates: \([0-9]*\) (sizes: \[\(.*\)\])/\1|\2/')
+    rust_num_dups=$(echo "$rust_dups" | cut -d'|' -f1)
+    rust_dup_sizes=$(echo "$rust_dups" | cut -d'|' -f2)
+    rust_remnant=$(echo "$rust_output" | grep "Remnant edges:" | sed 's/.*Remnant edges: //')
+
+    # --- C++ ---
+    # C++ needs mol file in cwd, named without extension.
+    cp "$molfile" "$WORK_DIR/${molname}.mol"
+    (cd "$WORK_DIR" && "$CPP_BIN" "$molname" > /dev/null 2>&1)
+
+    cpp_out_file="$WORK_DIR/${molname}Out"
+    cpp_pathway_file="$WORK_DIR/${molname}Pathway"
+
+    if [[ ! -f "$cpp_out_file" ]]; then
+        echo "SKIP (C++ produced no output)"
+        continue
+    fi
+
+    cpp_index=$(grep "assembly index:" "$cpp_out_file" | sed 's/.*assembly index: //')
+
+    # Parse the C++ pathway JSON with python for robustness.
+    if [[ ! -f "$cpp_pathway_file" ]]; then
+        echo "SKIP (C++ produced no pathway)"
+        continue
+    fi
+
+    cpp_summary=$(python3 -c "
+import json, sys
+with open('$cpp_pathway_file') as f:
+    data = json.load(f)
+dups = data.get('duplicates', [])
+sizes = sorted([len(d['Left']) for d in dups], reverse=True)
+remnant_edges = len(data.get('remnant', [{}])[0].get('Edges', []))
+removed_edges = len(data.get('removed_edges', []))
+print(f'{len(dups)}|{\",\".join(str(s) for s in sizes)}|{remnant_edges + removed_edges}')
+")
+    cpp_num_dups=$(echo "$cpp_summary" | cut -d'|' -f1)
+    cpp_dup_sizes=$(echo "$cpp_summary" | cut -d'|' -f2)
+    cpp_remnant=$(echo "$cpp_summary" | cut -d'|' -f3)
+
+    # --- Compare ---
+    # Sort duplicate sizes for comparison (both should be descending already).
+    rust_sizes_sorted=$(echo "$rust_dup_sizes" | tr ',' '\n' | tr -d ' ' | sort -rn | tr '\n' ',' | sed 's/,$//')
+    cpp_sizes_sorted=$(echo "$cpp_dup_sizes" | tr ',' '\n' | tr -d ' ' | sort -rn | tr '\n' ',' | sed 's/,$//')
+
+    ok=true
+    details=""
+
+    if [[ "$rust_index" != "$cpp_index" ]]; then
+        ok=false
+        details+="  index: rust=$rust_index cpp=$cpp_index\n"
+    fi
+    if [[ "$rust_num_dups" != "$cpp_num_dups" ]]; then
+        ok=false
+        details+="  num_dups: rust=$rust_num_dups cpp=$cpp_num_dups\n"
+    fi
+    if [[ "$rust_sizes_sorted" != "$cpp_sizes_sorted" ]]; then
+        ok=false
+        details+="  dup_sizes: rust=[$rust_sizes_sorted] cpp=[$cpp_sizes_sorted]\n"
+    fi
+    if [[ "$rust_remnant" != "$cpp_remnant" ]]; then
+        ok=false
+        details+="  remnant: rust=$rust_remnant cpp=$cpp_remnant\n"
+    fi
+
+    if $ok; then
+        echo "PASS (index=$rust_index dups=$rust_num_dups sizes=[$rust_sizes_sorted] remnant=$rust_remnant)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL"
+        echo -e "$details"
+        errors+=("$molname")
+        fail=$((fail + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if (( ${#errors[@]} > 0 )); then
+    echo "Failed molecules: ${errors[*]}"
+    exit 1
+fi
+
+# Clean up any C++ output files left from manual runs in the C++ directory.
+for molfile in "$MOL_DIR"/*.mol; do
+    molname="${molfile:t:r}"
+    rm -f "$CPP_DIR/${molname}Out" "$CPP_DIR/${molname}Pathway" \
+          "$CPP_DIR/${molname}.mol" "$CPP_DIR/${molname}.molOut" \
+          "$CPP_DIR/${molname}.molPathway"
+done

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -155,9 +155,12 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 /// - `cache`: Memoization cache storing previously searched assembly states.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
 /// - `best_pathway`: When `Some`, tracks the `(match_ix_sequence, leaf_fragments)`
-///    for the best decomposition path found so far. When `None`, pathway tracking
-///    is skipped entirely.
-/// - `path_so_far`: The sequence of match indices removed from root to this state.
+///    for the best decomposition path found so far. This is stored behind an
+///    `Arc<Mutex<...>>` so it can be safely updated from parallel threads.
+///    When `None`, pathway tracking is skipped entirely.
+/// - `path_so_far`: The sequence of match indices removed from root to this
+///    state. Each match index identifies a duplicate subgraph pair; this
+///    sequence records *which* duplicates were removed, in order.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: An updated upper bound on the assembly index. (Note: If this
@@ -206,7 +209,9 @@ pub fn recurse_index_search(
                 parallel_mode
             };
 
-            // Build the extended path for this child.
+            // Build the extended path for this child: append this match index
+            // to the path so far. This accumulates the full sequence of
+            // duplicate removals from the root state down to the current child.
             let child_path: Vec<usize> = if best_pathway.is_some() {
                 let mut p = path_so_far.to_vec();
                 p.push(match_ix);
@@ -246,7 +251,10 @@ pub fn recurse_index_search(
             let new_global = best_index.fetch_min(child_index, Relaxed);
 
             // If this child achieved a new global best and we are tracking
-            // pathways, update the shared pathway data.
+            // pathways, update the shared pathway data with the match sequence
+            // and leaf fragments. The leaf fragments (new_state.fragments())
+            // represent what's left of the molecule after all duplicates in
+            // child_path have been removed.
             if let Some(bp) = best_pathway {
                 if child_index < prev_best.min(new_global) {
                     let mut guard = bp.lock().unwrap();
@@ -374,7 +382,13 @@ pub fn index_search(
     kernel_mode: KernelMode,
     bounds: &[Bound],
     extract_pathway: bool,
-) -> (u32, u32, Option<usize>, Option<Vec<PathwayStep>>, Option<(Vec<usize>, Vec<BitSet>)>) {
+) -> (
+    u32,
+    u32,
+    Option<usize>,
+    Option<Vec<PathwayStep>>,
+    Option<(Vec<usize>, Vec<BitSet>)>,
+) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
         panic!("The chosen --kernel mode is not implemented yet!")
@@ -390,7 +404,11 @@ pub fn index_search(
     // Use an `Arc` to track the best assembly index across parallel threads.
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
 
-    // Optionally create shared pathway tracking state.
+    // Optionally create shared pathway tracking state. The tuple stores
+    // (match_sequence, leaf_fragments): the sequence of duplicate indices
+    // removed during the optimal search path, and the remaining fragments
+    // at the leaf state. These are passed to generate_pathway() for
+    // bottom-up reconstruction.
     let best_pathway = if extract_pathway {
         Some(Arc::new(Mutex::new((Vec::new(), Vec::new()))))
     } else {
@@ -449,7 +467,12 @@ pub fn index_search(
                     let mol_for_pathway = parse_mol.clone();
                     let matches_for_pathway = Matches::new(&mol_for_pathway, canonize_mode);
                     (
-                        Some(generate_pathway(&mol_for_pathway, &matches_for_pathway, match_seq, remnants)),
+                        Some(generate_pathway(
+                            &mol_for_pathway,
+                            &matches_for_pathway,
+                            match_seq,
+                            remnants,
+                        )),
                         Some((match_seq.clone(), remnants.clone())),
                     )
                 }
@@ -457,7 +480,13 @@ pub fn index_search(
             _ => (None, None),
         };
 
-        (index as u32, num_matches as u32, states_searched, pathway, decomposition)
+        (
+            index as u32,
+            num_matches as u32,
+            states_searched,
+            pathway,
+            decomposition,
+        )
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
         let (index, states_searched) = recurse_index_search(
@@ -485,7 +514,13 @@ pub fn index_search(
             None => (None, None),
         };
 
-        (index as u32, matches.len() as u32, Some(states_searched), pathway, decomposition)
+        (
+            index as u32,
+            matches.len() as u32,
+            Some(states_searched),
+            pathway,
+            decomposition,
+        )
     }
 }
 

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -21,7 +21,7 @@
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
@@ -38,6 +38,7 @@ use crate::{
     matches::Matches,
     memoize::{Cache, MemoizeMode},
     molecule::Molecule,
+    pathway::{generate_pathway, PathwayStep},
     state::State,
     utils::connected_components_under_edges,
 };
@@ -153,6 +154,10 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 /// - `bounds`: The list of bounding strategies to apply.
 /// - `cache`: Memoization cache storing previously searched assembly states.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
+/// - `best_pathway`: When `Some`, tracks the `(match_ix_sequence, leaf_fragments)`
+///    for the best decomposition path found so far. When `None`, pathway tracking
+///    is skipped entirely.
+/// - `path_so_far`: The sequence of match indices removed from root to this state.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: An updated upper bound on the assembly index. (Note: If this
@@ -167,6 +172,8 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
+    best_pathway: Option<&Arc<Mutex<(Vec<usize>, Vec<BitSet>)>>>,
+    path_so_far: &[usize],
 ) -> (usize, usize) {
     // If any bounds would prune this assembly state or if memoization is
     // enabled and this assembly state is preempted by the cached state, halt.
@@ -199,21 +206,57 @@ pub fn recurse_index_search(
                 parallel_mode
             };
 
+            // Build the extended path for this child.
+            let child_path: Vec<usize> = if best_pathway.is_some() {
+                let mut p = path_so_far.to_vec();
+                p.push(match_ix);
+                p
+            } else {
+                Vec::new()
+            };
+
+            let new_state = state.update(fragments, i, match_ix, h1.len());
+
+            // If this is a leaf state (no more matches can be removed) and we
+            // are tracking pathways, check if this is the new best.
+            if best_pathway.is_some() {
+                let child_index = new_state.index();
+                if child_index < best_index.load(Relaxed) {
+                    // This will be checked again after recursion, but for leaf
+                    // states we capture here.
+                }
+            }
+
             // Recurse using the remaining matches and updated fragments.
             let (child_index, child_states_searched) = recurse_index_search(
                 mol,
                 matches,
-                &state.update(fragments, i, match_ix, h1.len()),
+                &new_state,
                 best_index.clone(),
                 bounds,
                 &mut cache.clone(),
                 new_parallel,
+                best_pathway,
+                &child_path,
             );
 
             // Update the best assembly indices (across children states and the
             // entire search) and the number of descendant states searched.
-            best_child_index.fetch_min(child_index, Relaxed);
-            best_index.fetch_min(best_child_index.load(Relaxed), Relaxed);
+            let prev_best = best_child_index.fetch_min(child_index, Relaxed);
+            let new_global = best_index.fetch_min(child_index, Relaxed);
+
+            // If this child achieved a new global best and we are tracking
+            // pathways, update the shared pathway data.
+            if let Some(bp) = best_pathway {
+                if child_index < prev_best.min(new_global) {
+                    let mut guard = bp.lock().unwrap();
+                    // Double-check: only update if still the best.
+                    if child_index <= best_index.load(Relaxed) {
+                        *guard = (child_path, new_state.fragments().clone());
+                    }
+                }
+            }
+
             states_searched.fetch_add(child_states_searched, Relaxed);
         }
     };
@@ -255,6 +298,10 @@ pub fn recurse_index_search(
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
+/// - The assembly pathway as a `Vec<PathwayStep>` if `extract_pathway` is
+///   `true` and the search completes, and `None` otherwise.
+/// - The raw decomposition `(match_sequence, remnants)` if `extract_pathway`
+///   is `true` and the search completes, and `None` otherwise.
 ///
 /// # Example
 /// ```
@@ -276,7 +323,7 @@ pub fn recurse_index_search(
 ///
 /// // Compute the molecule's assembly index without parallelism, memoization,
 /// // kernelization, or bounds.
-/// let (slow_index, _, _) = index_search(
+/// let (slow_index, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -284,11 +331,12 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     false,
 /// );
 ///
 /// // Compute the molecule's assembly index with parallelism, memoization, and
 /// // some bounds.
-/// let (fast_index, _, _) = index_search(
+/// let (fast_index, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -296,10 +344,11 @@ pub fn recurse_index_search(
 ///     MemoizeMode::CanonIndex,
 ///     KernelMode::None,
 ///     &[Bound::Log, Bound::Int],
+///     false,
 /// );
 ///
 /// // Limit search to 1 ms, which should time out.
-/// let (index_bound, _, states_searched) = index_search(
+/// let (index_bound, _, states_searched, _, _) = index_search(
 ///     &anthracene,
 ///     Some(1),
 ///     CanonizeMode::TreeNauty,
@@ -307,6 +356,7 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     false,
 /// );
 ///
 /// assert_eq!(slow_index, 6);
@@ -323,7 +373,8 @@ pub fn index_search(
     memoize_mode: MemoizeMode,
     kernel_mode: KernelMode,
     bounds: &[Bound],
-) -> (u32, u32, Option<usize>) {
+    extract_pathway: bool,
+) -> (u32, u32, Option<usize>, Option<Vec<PathwayStep>>, Option<(Vec<usize>, Vec<BitSet>)>) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
         panic!("The chosen --kernel mode is not implemented yet!")
@@ -339,12 +390,21 @@ pub fn index_search(
     // Use an `Arc` to track the best assembly index across parallel threads.
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
 
+    // Optionally create shared pathway tracking state.
+    let best_pathway = if extract_pathway {
+        Some(Arc::new(Mutex::new((Vec::new(), Vec::new()))))
+    } else {
+        None
+    };
+
     // Search for the shortest assembly pathway recursively.
     if let Some(timeout) = timeout {
         // If a timeout is provided, we will search within an asynchronous task
         // that can be interrupted after the specified duration (see below). To
         // avoid subsequent scope issues, make copies of various variables.
         let best_index_copy = best_index.clone();
+        let best_pathway_copy = best_pathway.clone();
+        let parse_mol = mol.clone();
         let mol = mol.clone();
         let bounds = bounds.to_vec();
         let num_matches = matches.len();
@@ -362,6 +422,8 @@ pub fn index_search(
                     &bounds,
                     &mut cache,
                     parallel_mode,
+                    best_pathway_copy.as_ref(),
+                    &[],
                 ));
             });
             tktimeout(Duration::from_millis(timeout), recv).await
@@ -375,7 +437,27 @@ pub fn index_search(
             Err(_) => (best_index.load(Relaxed), None),
             _ => panic!("An unexpected error occurred in async index_search"),
         };
-        (index as u32, num_matches as u32, states_searched)
+
+        // Reconstruct the pathway if tracking was enabled and search completed.
+        let (pathway, decomposition) = match (&best_pathway, &states_searched) {
+            (Some(bp), Some(_)) => {
+                let guard = bp.lock().unwrap();
+                let (ref match_seq, ref remnants) = *guard;
+                if match_seq.is_empty() {
+                    (None, None)
+                } else {
+                    let mol_for_pathway = parse_mol.clone();
+                    let matches_for_pathway = Matches::new(&mol_for_pathway, canonize_mode);
+                    (
+                        Some(generate_pathway(&mol_for_pathway, &matches_for_pathway, match_seq, remnants)),
+                        Some((match_seq.clone(), remnants.clone())),
+                    )
+                }
+            }
+            _ => (None, None),
+        };
+
+        (index as u32, num_matches as u32, states_searched, pathway, decomposition)
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
         let (index, states_searched) = recurse_index_search(
@@ -386,8 +468,24 @@ pub fn index_search(
             bounds,
             &mut cache,
             parallel_mode,
+            best_pathway.as_ref(),
+            &[],
         );
-        (index as u32, matches.len() as u32, Some(states_searched))
+
+        // Reconstruct the pathway if tracking was enabled.
+        let (pathway, decomposition) = match best_pathway {
+            Some(bp) => {
+                let guard = bp.lock().unwrap();
+                let (ref match_seq, ref remnants) = *guard;
+                (
+                    Some(generate_pathway(mol, &matches, match_seq, remnants)),
+                    Some((match_seq.clone(), remnants.clone())),
+                )
+            }
+            None => (None, None),
+        };
+
+        (index as u32, matches.len() as u32, Some(states_searched), pathway, decomposition)
     }
 }
 
@@ -422,6 +520,7 @@ pub fn index(mol: &Molecule) -> u32 {
         MemoizeMode::CanonIndex,
         KernelMode::None,
         &[Bound::Int, Bound::MatchableEdges],
+        false,
     )
     .0
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod kernels;
 pub mod matches;
 pub mod memoize;
 mod nauty;
+pub mod pathway;
 pub mod state;
 mod vf3;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use assembly_theory::{
     canonize::CanonizeMode,
     kernels::KernelMode,
     loader::parse_molfile_str,
+    matches::Matches,
     memoize::MemoizeMode,
+    pathway::edges_as_vertex_pairs,
 };
 use clap::{Args, Parser};
 
@@ -56,6 +58,10 @@ struct Cli {
     /// Strategy for performing graph kernelization during the search phase.
     #[arg(long, value_enum, default_value_t = KernelMode::None)]
     kernel: KernelMode,
+
+    /// Extract and print the assembly pathway (bottom-up reconstruction).
+    #[arg(long)]
+    extract_pathway: bool,
 }
 
 #[derive(Args, Debug)]
@@ -109,7 +115,7 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, num_matches, states_searched) = index_search(
+    let (index, num_matches, states_searched, pathway, decomposition) = index_search(
         &mol,
         cli.timeout,
         cli.canonize,
@@ -117,6 +123,7 @@ fn main() -> Result<()> {
         cli.memoize,
         cli.kernel,
         boundlist,
+        cli.extract_pathway,
     );
 
     // Print final output, depending on --verbose.
@@ -139,6 +146,42 @@ fn main() -> Result<()> {
         (false, None) => {
             println!("<= {index} (timed out)");
         }
+    }
+
+    // Print the assembly pathway if extracted.
+    if let Some(ref steps) = pathway {
+        println!("\nAssembly Pathway ({} steps):", steps.len());
+        for (i, step) in steps.iter().enumerate() {
+            println!("  Step {}: {}", i + 1, step);
+        }
+    }
+
+    // Print the raw decomposition (C++ comparable) if available.
+    if let Some((ref match_seq, _)) = decomposition {
+        let matches = Matches::new(&mol, cli.canonize);
+        println!("\nDecomposition (duplicates largest-first):");
+        for &mix in match_seq.iter() {
+            let (h1, h2) = matches.match_fragments(mix);
+            let left = edges_as_vertex_pairs(&mol, h1);
+            let right = edges_as_vertex_pairs(&mol, h2);
+            println!("  Left:  {:?}", left);
+            println!("  Right: {:?}", right);
+        }
+        let mut present = bit_set::BitSet::with_capacity(mol.graph().edge_count());
+        present.extend(mol.graph().edge_indices().map(|ix| ix.index()));
+        for &mix in match_seq.iter() {
+            let (_, h2) = matches.match_fragments(mix);
+            present.difference_with(h2);
+        }
+        println!("  Remnant: {:?}", edges_as_vertex_pairs(&mol, &present));
+
+        let dup_sizes: Vec<usize> = match_seq
+            .iter()
+            .map(|&mix| matches.match_fragments(mix).0.len())
+            .collect();
+        println!("\n  Summary:");
+        println!("    Duplicates: {} (sizes: {:?})", dup_sizes.len(), dup_sizes);
+        println!("    Remnant edges: {}", present.len());
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,7 +156,13 @@ fn main() -> Result<()> {
         }
     }
 
-    // Print the raw decomposition (C++ comparable) if available.
+    // Print the raw decomposition if available. This outputs the duplicate
+    // pairs and remnant edges in a format comparable to the C++ implementation
+    // (assemblycpp-v5). Each duplicate is a pair of isomorphic subgraphs:
+    //   "Left"  = the copy that was kept (template)
+    //   "Right" = the copy that was removed (duplicate)
+    //   "Remnant" = bonds left over after all duplicates are removed
+    // The assembly index = num_duplicates + num_remnant_edges.
     if let Some((ref match_seq, _)) = decomposition {
         let matches = Matches::new(&mol, cli.canonize);
         println!("\nDecomposition (duplicates largest-first):");
@@ -180,7 +186,11 @@ fn main() -> Result<()> {
             .map(|&mix| matches.match_fragments(mix).0.len())
             .collect();
         println!("\n  Summary:");
-        println!("    Duplicates: {} (sizes: {:?})", dup_sizes.len(), dup_sizes);
+        println!(
+            "    Duplicates: {} (sizes: {:?})",
+            dup_sizes.len(),
+            dup_sizes
+        );
         println!("    Remnant edges: {}", present.len());
     }
 

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,0 +1,219 @@
+//! Assembly pathway reconstruction from top-down decomposition results.
+//!
+//! Implements the `Generate_Pathway` algorithm from the supplementary
+//! information of [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964).
+
+use std::fmt;
+
+use bit_set::BitSet;
+use petgraph::graph::EdgeIndex;
+
+use crate::{matches::Matches, molecule::Molecule};
+
+/// Format an edge set as a list of `(src, dst)` vertex pairs.
+pub fn edges_as_vertex_pairs(mol: &Molecule, edges: &BitSet) -> Vec<(usize, usize)> {
+    edges
+        .iter()
+        .map(|e| {
+            let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+            (src.index(), dst.index())
+        })
+        .collect()
+}
+
+/// A single step in an assembly pathway: joining two pieces into one.
+#[derive(Debug, Clone)]
+pub struct PathwayStep {
+    /// First piece being joined (edge set).
+    pub piece_a: BitSet,
+    /// Second piece being joined (edge set).
+    pub piece_b: BitSet,
+    /// The result of joining the two pieces (union of edge sets).
+    pub result: BitSet,
+}
+
+impl fmt::Display for PathwayStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let a: Vec<usize> = self.piece_a.iter().collect();
+        let b: Vec<usize> = self.piece_b.iter().collect();
+        let r: Vec<usize> = self.result.iter().collect();
+        write!(f, "{:?} + {:?} -> {:?}", a, b, r)
+    }
+}
+
+/// Check whether two edge sets share at least one node (vertex) in the
+/// molecular graph.
+fn shares_node(mol: &Molecule, a: &BitSet, b: &BitSet) -> bool {
+    let mut nodes_a = BitSet::with_capacity(mol.graph().node_count());
+    for e in a {
+        let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+        nodes_a.insert(src.index());
+        nodes_a.insert(dst.index());
+    }
+    for e in b {
+        let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+        if nodes_a.contains(src.index()) || nodes_a.contains(dst.index()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// `Consistent_Join`: merge any two pieces sharing a vertex, recording each
+/// join as a pathway step. Returns `true` if any join was performed.
+fn consistent_join(mol: &Molecule, pieces: &mut Vec<BitSet>, steps: &mut Vec<PathwayStep>) -> bool {
+    let mut joined = false;
+    let mut i = 0;
+    while i < pieces.len() {
+        let mut j = i + 1;
+        let mut did_join = false;
+        while j < pieces.len() {
+            if shares_node(mol, &pieces[i], &pieces[j]) {
+                // Join pieces[j] into pieces[i].
+                let piece_a = pieces[i].clone();
+                let piece_b = pieces.swap_remove(j);
+                pieces[i].union_with(&piece_b);
+                steps.push(PathwayStep {
+                    piece_a,
+                    piece_b,
+                    result: pieces[i].clone(),
+                });
+                joined = true;
+                did_join = true;
+                // Don't increment j — a new element may have been swapped in.
+            } else {
+                j += 1;
+            }
+        }
+        if !did_join {
+            i += 1;
+        }
+        // If we joined, re-check pieces[i] against remaining pieces.
+    }
+    joined
+}
+
+/// Find pieces that overlap with a given fragment (by shared nodes).
+fn filter_pieces(mol: &Molecule, pieces: &[BitSet], fragment: &BitSet) -> Vec<usize> {
+    pieces
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| shares_node(mol, p, fragment))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// `Duplicate_Construction`: process duplicates (matched fragment pairs) from
+/// smallest to largest, adding copies or first reassembling containing pieces.
+fn duplicate_construction(
+    mol: &Molecule,
+    duplicates: &[(BitSet, BitSet)],
+    pieces: &mut Vec<BitSet>,
+    steps: &mut Vec<PathwayStep>,
+) {
+    for (h1, h2) in duplicates {
+        // Check if h2 (the "template") is already exactly one of the pieces.
+        let exact_match = pieces.iter().position(|p| p == h2);
+        if let Some(_) = exact_match {
+            // The template is already a piece; just add the copy.
+            pieces.push(h1.clone());
+        } else {
+            // Filter pieces that overlap with h2.
+            let filtered_ixs = filter_pieces(mol, pieces, h2);
+            if filtered_ixs.is_empty() {
+                // Template edges are already part of a larger assembled piece;
+                // just add the copy.
+                pieces.push(h1.clone());
+                continue;
+            }
+
+            // Extract filtered pieces and remove them from the main list.
+            // Remove in reverse index order to avoid invalidating indices.
+            let mut filtered: Vec<BitSet> = Vec::new();
+            let mut sorted_ixs = filtered_ixs;
+            sorted_ixs.sort_unstable_by(|a, b| b.cmp(a));
+            for ix in &sorted_ixs {
+                filtered.push(pieces.swap_remove(*ix));
+            }
+
+            // Join the filtered pieces until they form one piece.
+            while filtered.len() > 1 {
+                if !consistent_join(mol, &mut filtered, steps) {
+                    break;
+                }
+            }
+
+            // Add both the reassembled piece and the duplicate copy.
+            pieces.extend(filtered);
+            pieces.push(h1.clone());
+        }
+    }
+}
+
+/// Reconstruct the bottom-up assembly pathway from the top-down decomposition
+/// results.
+///
+/// # Arguments
+/// - `mol`: The molecule.
+/// - `matches`: The matches structure used during the search.
+/// - `match_sequence`: The sequence of global `match_ix` values from root to
+///   leaf of the optimal decomposition path.
+/// - `remnants`: The leaf state's fragments (the pieces left after all
+///   duplicates have been removed). Note: these may exclude singleton (single-
+///   edge) fragments that were dropped during the search.
+///
+/// # Returns
+/// A vector of [`PathwayStep`]s representing the assembly pathway from basic
+/// fragments to the complete molecule.
+pub fn generate_pathway(
+    mol: &Molecule,
+    matches: &Matches,
+    match_sequence: &[usize],
+    _remnants: &[BitSet],
+) -> Vec<PathwayStep> {
+    let mut steps: Vec<PathwayStep> = Vec::new();
+
+    // Build the list of duplicates from the match sequence. Each duplicate is
+    // (copy, template): the search kept h1 (template) and discarded h2 (copy).
+    // For bottom-up reconstruction, we reverse so smallest fragments come first.
+    let mut duplicates: Vec<(BitSet, BitSet)> = match_sequence
+        .iter()
+        .map(|&mix| {
+            let (h1, h2) = matches.match_fragments(mix);
+            (h2.clone(), h1.clone()) // (copy, template)
+        })
+        .collect();
+    duplicates.reverse();
+
+    // Compute the edges present at the leaf level: all molecule edges minus
+    // the net-removed edges (h2 from each decomposition step).
+    let mut present_edges = BitSet::with_capacity(mol.graph().edge_count());
+    present_edges.extend(mol.graph().edge_indices().map(|ix| ix.index()));
+    for &mix in match_sequence.iter() {
+        let (_, h2) = matches.match_fragments(mix);
+        present_edges.difference_with(h2);
+    }
+
+    // Start pieces as individual edges (basic units).
+    let mut pieces: Vec<BitSet> = present_edges
+        .iter()
+        .map(|e| {
+            let mut bs = BitSet::with_capacity(mol.graph().edge_count());
+            bs.insert(e);
+            bs
+        })
+        .collect();
+
+    // Process duplicates: for each one, reassemble its template from basic
+    // pieces if needed, then add the copy.
+    duplicate_construction(mol, &duplicates, &mut pieces, &mut steps);
+
+    // Iteratively join remaining pieces that share vertices.
+    loop {
+        if !consistent_join(mol, &mut pieces, &mut steps) {
+            break;
+        }
+    }
+
+    steps
+}

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -22,13 +22,18 @@ pub fn edges_as_vertex_pairs(mol: &Molecule, edges: &BitSet) -> Vec<(usize, usiz
 }
 
 /// A single step in an assembly pathway: joining two pieces into one.
+///
+/// In chemical terms, this represents the combination of two molecular
+/// fragments (each described by its bond indices) into a larger fragment.
+/// The full sequence of `PathwayStep`s rebuilds the molecule bottom-up,
+/// starting from individual bonds and ending with the complete molecule.
 #[derive(Debug, Clone)]
 pub struct PathwayStep {
-    /// First piece being joined (edge set).
+    /// First piece being joined (set of bond/edge indices in the molecule).
     pub piece_a: BitSet,
-    /// Second piece being joined (edge set).
+    /// Second piece being joined (set of bond/edge indices in the molecule).
     pub piece_b: BitSet,
-    /// The result of joining the two pieces (union of edge sets).
+    /// The result of joining the two pieces (union of their bond sets).
     pub result: BitSet,
 }
 
@@ -42,7 +47,8 @@ impl fmt::Display for PathwayStep {
 }
 
 /// Check whether two edge sets share at least one node (vertex) in the
-/// molecular graph.
+/// molecular graph. Two fragments that share a node are "adjacent" and can
+/// be joined into a larger connected fragment.
 fn shares_node(mol: &Molecule, a: &BitSet, b: &BitSet) -> bool {
     let mut nodes_a = BitSet::with_capacity(mol.graph().node_count());
     for e in a {
@@ -59,8 +65,12 @@ fn shares_node(mol: &Molecule, a: &BitSet, b: &BitSet) -> bool {
     false
 }
 
-/// `Consistent_Join`: merge any two pieces sharing a vertex, recording each
-/// join as a pathway step. Returns `true` if any join was performed.
+/// `Consistent_Join` (from Seet et al.): repeatedly merge any two pieces that
+/// share a vertex (atom), recording each merge as a pathway step. Returns
+/// `true` if at least one join was performed.
+///
+/// This is the "glue" operation: after duplicates are introduced, adjacent
+/// fragments are iteratively fused until no more merges are possible.
 fn consistent_join(mol: &Molecule, pieces: &mut Vec<BitSet>, steps: &mut Vec<PathwayStep>) -> bool {
     let mut joined = false;
     let mut i = 0;
@@ -103,8 +113,14 @@ fn filter_pieces(mol: &Molecule, pieces: &[BitSet], fragment: &BitSet) -> Vec<us
         .collect()
 }
 
-/// `Duplicate_Construction`: process duplicates (matched fragment pairs) from
-/// smallest to largest, adding copies or first reassembling containing pieces.
+/// `Duplicate_Construction` (from Seet et al.): process duplicates from
+/// smallest to largest. For each duplicate pair (copy, template), either:
+/// - the template already exists as a piece → just add the copy, or
+/// - the template's bonds are split across multiple pieces → reassemble
+///   those pieces first (via `consistent_join`), then add the copy.
+///
+/// This mirrors the top-down search in reverse: the search removed duplicates
+/// largest-first, so reconstruction adds them back smallest-first.
 fn duplicate_construction(
     mol: &Molecule,
     duplicates: &[(BitSet, BitSet)],
@@ -153,18 +169,24 @@ fn duplicate_construction(
 /// Reconstruct the bottom-up assembly pathway from the top-down decomposition
 /// results.
 ///
+/// The top-down search finds the optimal way to decompose a molecule by
+/// repeatedly removing duplicate subgraphs. This function reverses that
+/// process: starting from the individual bonds left at the leaf state, it
+/// rebuilds the molecule step-by-step by reintroducing duplicates and
+/// fusing adjacent fragments.
+///
 /// # Arguments
 /// - `mol`: The molecule.
 /// - `matches`: The matches structure used during the search.
 /// - `match_sequence`: The sequence of global `match_ix` values from root to
-///   leaf of the optimal decomposition path.
-/// - `remnants`: The leaf state's fragments (the pieces left after all
-///   duplicates have been removed). Note: these may exclude singleton (single-
-///   edge) fragments that were dropped during the search.
+///   leaf of the optimal decomposition path. Each index identifies a pair of
+///   isomorphic edge-disjoint subgraphs (a "duplicate").
+/// - `remnants`: The leaf state's fragments (unused; remnants are recomputed
+///   from `match_sequence` for consistency).
 ///
 /// # Returns
 /// A vector of [`PathwayStep`]s representing the assembly pathway from basic
-/// fragments to the complete molecule.
+/// fragments (individual bonds) to the complete molecule.
 pub fn generate_pathway(
     mol: &Molecule,
     matches: &Matches,

--- a/src/python.rs
+++ b/src/python.rs
@@ -516,7 +516,12 @@ pub fn _pathway_search(
     memoize_str: &str,
     kernel_str: &str,
     bound_strs: Vec<String>,
-) -> PyResult<(u32, u32, Option<usize>, Option<Vec<HashMap<String, Vec<usize>>>>)> {
+) -> PyResult<(
+    u32,
+    u32,
+    Option<usize>,
+    Option<Vec<HashMap<String, Vec<usize>>>>,
+)> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol = parse_molfile_str(mol_block)?;
 
@@ -549,7 +554,8 @@ pub fn _pathway_search(
     let pybounds = process_bound_strs(bound_strs)?;
     let boundlist = make_boundlist(&pybounds);
 
-    // Compute assembly index with pathway extraction.
+    // Compute assembly index with pathway extraction enabled (last arg = true).
+    // The 5th return value (_) is the raw match sequence, not needed for the Python API.
     let (idx, num_matches, states_searched, pathway, _) = index_search(
         &mol,
         timeout,
@@ -561,7 +567,8 @@ pub fn _pathway_search(
         true,
     );
 
-    // Convert pathway steps to Python-friendly dicts.
+    // Convert PathwayStep structs to Python-friendly dicts with string keys.
+    // Each step's piece_a, piece_b, result (BitSets) become Vec<usize> of bond indices.
     let py_pathway = pathway.map(|steps| {
         steps
             .iter()

--- a/src/python.rs
+++ b/src/python.rs
@@ -60,6 +60,7 @@
 //! at.index(mol_block)  # 6
 //! ```
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use pyo3::{
@@ -448,7 +449,7 @@ pub fn _index_search(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    Ok(index_search(
+    let (idx, num_matches, states_searched, _, _) = index_search(
         &mol,
         timeout,
         canonize_mode,
@@ -456,7 +457,125 @@ pub fn _index_search(
         memoize_mode,
         kernel_mode,
         &boundlist,
-    ))
+        false,
+    );
+    Ok((idx, num_matches, states_searched))
+}
+
+/// Computes a molecule's assembly index and extracts the assembly pathway
+/// using a top-down recursive search, parameterized by the specified options.
+///
+/// Python version of [`index_search`] with pathway extraction enabled.
+///
+/// # Python Parameters
+///
+/// - `mol_block`: The contents of a `.mol` file as a `str`.
+/// - `timeout`: An `int` duration in milliseconds after which search is
+/// stopped, or `None` if search is run until the true assembly index is found.
+/// - `canonize_str`: A canonization mode from [`"nauty"`, `"faulon"`,
+/// `"tree-nauty"` (default), `"tree-faulon"`].
+/// - `parallel_str`: A parallelization mode from [`"none"`, `"depth-one"`
+/// (default), `"always"`].
+/// - `memoize_str`: A memoization mode from [`none`, `canon-index` (default)].
+/// - `kernel_str`: A kernelization mode from [`"none"` (default), `"once"`,
+/// `"depth-one"`, `"always"`].
+/// - `bound_strs`: A list of bounds. Default: `["int", "matchable-edges"]`.
+///
+/// # Python Returns
+///
+/// A 4-tuple containing:
+/// - The molecule's `int` assembly index (or an upper bound if timed out).
+/// - The molecule's `int` number of edge-disjoint isomorphic subgraph pairs.
+/// - The `int` number of assembly states searched, or `None` if timed out.
+/// - A `list` of pathway steps, where each step is a dict with keys
+///   `"piece_a"`, `"piece_b"`, and `"result"` (each a list of edge indices),
+///   or `None` if timed out.
+///
+/// # Python Example
+///
+/// ```custom,{class=language-python}
+/// import assembly_theory as at
+///
+/// # Load a mol block from file.
+/// with open('data/checks/benzene.mol') as f:
+///     mol_block = f.read()
+///
+/// # Calculate the molecule's assembly index and extract pathway.
+/// (index, num_matches, states_searched, pathway) = at.pathway_search(mol_block)
+///
+/// for step in pathway:
+///     print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
+/// ```
+#[pyfunction(name = "pathway_search")]
+#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()]), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"]))")]
+pub fn _pathway_search(
+    mol_block: &str,
+    timeout: Option<u64>,
+    canonize_str: &str,
+    parallel_str: &str,
+    memoize_str: &str,
+    kernel_str: &str,
+    bound_strs: Vec<String>,
+) -> PyResult<(u32, u32, Option<usize>, Option<Vec<HashMap<String, Vec<usize>>>>)> {
+    // Parse the .mol file contents as a molecule::Molecule.
+    let mol = parse_molfile_str(mol_block)?;
+
+    // Parse the various modes and bound options.
+    let canonize_mode = match PyCanonizeMode::from_str(canonize_str) {
+        Ok(PyCanonizeMode::Nauty) => CanonizeMode::Nauty,
+        Ok(PyCanonizeMode::Faulon) => CanonizeMode::Faulon,
+        Ok(PyCanonizeMode::TreeNauty) => CanonizeMode::TreeNauty,
+        Ok(PyCanonizeMode::TreeFaulon) => CanonizeMode::TreeFaulon,
+        Err(e) => return Err(e),
+    };
+    let parallel_mode = match PyParallelMode::from_str(parallel_str) {
+        Ok(PyParallelMode::None) => ParallelMode::None,
+        Ok(PyParallelMode::DepthOne) => ParallelMode::DepthOne,
+        Ok(PyParallelMode::Always) => ParallelMode::Always,
+        Err(e) => return Err(e),
+    };
+    let memoize_mode = match PyMemoizeMode::from_str(memoize_str) {
+        Ok(PyMemoizeMode::None) => MemoizeMode::None,
+        Ok(PyMemoizeMode::CanonIndex) => MemoizeMode::CanonIndex,
+        Err(e) => return Err(e),
+    };
+    let kernel_mode = match PyKernelMode::from_str(kernel_str) {
+        Ok(PyKernelMode::None) => KernelMode::None,
+        Ok(PyKernelMode::Once) => KernelMode::Once,
+        Ok(PyKernelMode::DepthOne) => KernelMode::DepthOne,
+        Ok(PyKernelMode::Always) => KernelMode::Always,
+        Err(e) => return Err(e),
+    };
+    let pybounds = process_bound_strs(bound_strs)?;
+    let boundlist = make_boundlist(&pybounds);
+
+    // Compute assembly index with pathway extraction.
+    let (idx, num_matches, states_searched, pathway, _) = index_search(
+        &mol,
+        timeout,
+        canonize_mode,
+        parallel_mode,
+        memoize_mode,
+        kernel_mode,
+        &boundlist,
+        true,
+    );
+
+    // Convert pathway steps to Python-friendly dicts.
+    let py_pathway = pathway.map(|steps| {
+        steps
+            .iter()
+            .map(|step| {
+                let mut d = HashMap::new();
+                d.insert("piece_a".to_string(), step.piece_a.iter().collect());
+                d.insert("piece_b".to_string(), step.piece_b.iter().collect());
+                d.insert("result".to_string(), step.result.iter().collect());
+                d
+            })
+            .collect()
+    });
+
+    Ok((idx, num_matches, states_searched, py_pathway))
 }
 
 /// A Python wrapper for the assembly_theory Rust crate.
@@ -468,5 +587,6 @@ fn _assembly_theory(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(_depth, m)?)?;
     m.add_function(wrap_pyfunction!(_index, m)?)?;
     m.add_function(wrap_pyfunction!(_index_search, m)?)?;
+    m.add_function(wrap_pyfunction!(_pathway_search, m)?)?;
     Ok(())
 }

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -71,7 +71,7 @@ fn test_reference_dataset(
         .expect(&format!("Failed to parse {name:?}"));
 
         // Calculate the molecule's assembly index.
-        let (index, _, _) = index_search(
+        let (index, _, _, _, _) = index_search(
             &mol,
             None,
             canonize_mode,
@@ -79,6 +79,7 @@ fn test_reference_dataset(
             memoize_mode,
             kernel_mode,
             bounds,
+            false,
         );
 
         // Compare calculated assembly index to ground truth.


### PR DESCRIPTION
Pull request as discussed, implementing pathway reconstruction, written with the help of Claude.

Description:

- implements the algorithm in Seet et al., touching mostly `assembly.rs` (+144) and `pathway.rs` (new, +241)
- adds new CLI arg `--extract-pathway`
- adds Python module implementation `pathway_search`
- validates pathway reconstruction against `AssemblyCPP` using `validate_pathways.py‎`
- passes existing tests and shows no regression
- updates `README.md` and existing tests/benchmarks