### PR TITLE
Implement searching for alternative pathways

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ A full list of options for returning more information or customizing the assembl
 ./target/release/assembly-theory --help
 ```
 
+To extract and print the assembly pathway (the step-by-step reconstruction of the molecule from its basic fragments), use the `--extract-pathway` flag:
+
+```shell
+./target/release/assembly-theory data/checks/anthracene.mol --extract-pathway
+```
+
+To collect multiple distinct optimal pathways (same assembly index, different duplicates), add `--alternative-pathways`:
+
+```shell
+./target/release/assembly-theory data/checks/anthracene.mol --alternative-pathways --max-pathways 5
+```
+
 
 ### Tests and Benchmarks
 
@@ -115,6 +127,16 @@ anthracene = Chem.MolToMolBlock(anthracene)
 
 # Calculate the molecule's assembly index.
 at.index(anthracene)  # 6
+
+# Extract the assembly pathway.
+(index, num_matches, states_searched, pathway) = at.pathway_search(anthracene)
+
+for step in pathway:
+    print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
+
+# Collect alternative pathways that use different duplicates.
+(index, num_matches, states_searched, pathway, alternatives, alt_seqs) = at.pathway_search(
+    anthracene, alternative_pathways=True, max_pathways=5)
 ```
 
 See the [`assembly_theory::python` documentation](https://docs.rs/assembly-theory/latest/assembly_theory/python) for a complete list of functions exposed to the Python package along with usage examples.

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -126,6 +126,8 @@ pub fn bench_bounds(c: &mut Criterion) {
                                     bounds,
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    None,
+                                    &[],
                                 );
                                 total_time += start.elapsed();
                             }
@@ -190,6 +192,8 @@ pub fn bench_memoize(c: &mut Criterion) {
                                     &[Bound::Int, Bound::MatchableEdges],
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    None,
+                                    &[],
                                 );
                                 total_time += start.elapsed();
                             }

--- a/python/README.md
+++ b/python/README.md
@@ -84,6 +84,27 @@ anthracene = Chem.MolToMolBlock(anthracene)
 at.index(anthracene)  # 6
 ```
 
+### Extracting Assembly Pathways
+
+Use `pathway_search` to extract the optimal construction pathway and, optionally, alternative pathways using different duplicates:
+
+```python
+import assembly_theory as at
+
+with open("anthracene.mol") as f:
+    mol_block = f.read()
+
+# Extract the primary pathway.
+index, num_matches, states_searched, pathway = at.pathway_search(mol_block)
+for step in pathway:
+    print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
+
+# Collect up to 5 alternative pathways.
+index, num_matches, states_searched, pathway, alternatives, alt_seqs = at.pathway_search(
+    mol_block, alternative_pathways=True, max_pathways=5)
+print(f"Found {len(alternatives) if alternatives else 0} alternative pathway(s)")
+```
+
 
 ## API Reference
 

--- a/python/tests/test_assembly_theory.py
+++ b/python/tests/test_assembly_theory.py
@@ -149,3 +149,70 @@ def test_index_search_bad_bound():
         at.index_search(mol_block, bound_strs=["int", "invalid-bound"])
 
     assert e.type is ValueError and "Invalid bound" in str(e.value)
+
+
+def test_pathway_search():
+    with open(osp.join("data", "checks", "anthracene.mol")) as f:
+        mol_block = f.read()
+
+    (index, num_matches, states_searched, pathway) = at.pathway_search(mol_block)
+    assert index == 6
+    assert pathway is not None
+    assert len(pathway) > 0
+
+    for step in pathway:
+        assert "piece_a" in step
+        assert "piece_b" in step
+        assert "result" in step
+
+
+def test_pathway_search_alternative_pathways():
+    with open(osp.join("data", "checks", "anthracene.mol")) as f:
+        mol_block = f.read()
+
+    (index, num_matches, states_searched, pathway, alternatives, alt_match_seqs) = at.pathway_search(
+        mol_block, alternative_pathways=True, max_pathways=5
+    )
+    assert index == 6
+    assert pathway is not None
+
+    # Anthracene should produce at least one alternative pathway.
+    assert alternatives is not None
+    assert len(alternatives) >= 1
+
+    # Alternative match sequences should also be present and match count.
+    assert alt_match_seqs is not None
+    assert len(alt_match_seqs) == len(alternatives)
+
+    # Each match sequence should be a non-empty list of match indices.
+    for seq in alt_match_seqs:
+        assert len(seq) > 0
+
+    # Each alternative should be a valid list of steps.
+    for alt in alternatives:
+        assert len(alt) > 0
+        for step in alt:
+            assert "piece_a" in step
+            assert "piece_b" in step
+            assert "result" in step
+
+
+def test_pathway_search_max_pathways_cap():
+    with open(osp.join("data", "checks", "anthracene.mol")) as f:
+        mol_block = f.read()
+
+    (_, _, _, _, alternatives, _) = at.pathway_search(
+        mol_block, alternative_pathways=True, max_pathways=2
+    )
+    # Total pathways (primary + alternatives) should not exceed max_pathways.
+    if alternatives is not None:
+        assert len(alternatives) <= 1  # primary is separate, so alternatives <= max-1
+
+
+def test_pathway_search_no_alternatives_by_default():
+    """Without alternative_pathways=True, return is a 4-tuple."""
+    with open(osp.join("data", "checks", "anthracene.mol")) as f:
+        mol_block = f.read()
+
+    result = at.pathway_search(mol_block)
+    assert len(result) == 4

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,3 +68,15 @@ Calculate assembly indices using:
 Both [`assembly_go`](https://github.com/croningp/assembly_go) and [`assemblycpp-v5`](https://github.com/croningp/assemblycpp-v5) are open-source software for calculating assembly indices.
 We do not package their source code or executables with our library, but they can be obtained from GitHub if non-self-referential ground truth is desired.
 Otherwise, a release build of `assembly-theory` is created and used.
+
+
+### `compare_pathways.sh`
+
+Compares the assembly pathway output of the Rust `assembly-theory` binary (`--extract-pathway`) against the C++ `assemblycpp-v5` binary across all molecules in `data/checks/`.
+Validates that the assembly index, number of duplicates, duplicate sizes, and remnant edge count agree between both implementations.
+
+Expects the [`assemblycpp-v5`](https://github.com/croningp/assemblycpp-v5) repository to be checked out alongside this repository (i.e., at `../../assemblycpp-v5` relative to this script).
+
+```shell
+zsh compare_pathways.sh
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -80,3 +80,17 @@ Expects the [`assemblycpp-v5`](https://github.com/croningp/assemblycpp-v5) repos
 ```shell
 zsh compare_pathways.sh
 ```
+
+
+### `validate_pathways.py`
+
+Validates alternative assembly pathways produced by `pathway_search(alternative_pathways=True)`. For each molecule, checks that:
+
+1. Every pathway step produces a valid fragment (union of piece_a and piece_b equals result).
+2. All alternative pathways have the same assembly index as the primary pathway.
+3. Alternative pathways are distinct (different sets of match indices).
+
+```shell
+python validate_pathways.py data/checks/*.mol
+python validate_pathways.py data/gdb13_1201/*.mol
+```

--- a/scripts/compare_pathways.sh
+++ b/scripts/compare_pathways.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env zsh
+# =============================================================================
+# Compare assembly pathway outputs between Rust and C++ implementations.
+#
+# BACKGROUND
+# ----------
+# Both codebases compute a molecule's assembly index by finding pairs of
+# edge-disjoint isomorphic subgraphs ("duplicates") in a top-down search.
+# The assembly index = total_edges - 1 - sum(dup_sizes - 1).
+#
+# OUTPUT FORMATS
+# --------------
+# Rust (--extract-pathway):
+#   Prints a bottom-up pathway (explicit join steps) and a decomposition
+#   summary with duplicate pairs as vertex-pair edge lists.
+#   "Remnant edges" = total_edges - sum(duplicate Right sizes)
+#     i.e., all edges not accounted for by duplicate removal.
+#
+# C++ (writes <name>Pathway JSON):
+#   Outputs the molecule graph, a "remnant" subgraph, a "duplicates" list,
+#   and a "removed_edges" list.
+#   The C++ preprocesses the molecule BEFORE search: edges whose chemical
+#   signature (atom_type + bond_type + atom_type) appears only once in the
+#   molecule are stripped as "removed_edges" — they can never be part of a
+#   duplicate pair. The C++ "remnant" only contains the remaining edges.
+#   So: C++ remnant + len(removed_edges) = Rust remnant.
+#
+# WHAT THIS SCRIPT COMPARES
+# -------------------------
+# For each .mol file in data/checks/, runs both implementations and compares:
+#   1. Assembly index (should be identical)
+#   2. Number of duplicate pairs (should be identical)
+#   3. Duplicate sizes, sorted descending (should be identical)
+#   4. Remnant edge count: Rust remnant vs C++ (remnant + removed_edges)
+#      These should match because both equal total_edges - sum(dup sizes).
+#
+# The specific edges in the remnant/duplicates may differ between runs (the
+# search is nondeterministic due to parallelism and HashMap ordering), but the
+# structural invariants above must always agree.
+#
+# NOTES
+# -----
+# - The C++ binary expects input WITHOUT .mol extension; it appends .mol
+#   internally. It also requires the .mol file in the current directory.
+# - Some molecules (morphine, cyanidin) may take minutes in the C++ binary.
+# - Expects assemblycpp-v5 to be checked out alongside this repository
+#   (i.e., at ../../assemblycpp-v5 relative to this script).
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="${0:A:h}"
+RUST_DIR="$SCRIPT_DIR/.."
+CPP_DIR="$SCRIPT_DIR/../../assemblycpp-v5"
+RUST_BIN="$RUST_DIR/target/debug/assembly-theory"
+CPP_BIN="$CPP_DIR/build/bin/assembly"
+MOL_DIR="$RUST_DIR/data/checks"
+WORK_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Build Rust binary if needed.
+if [[ ! -x "$RUST_BIN" ]]; then
+    echo "Building Rust binary..."
+    (cd "$RUST_DIR" && cargo build)
+fi
+
+# Check C++ binary exists.
+if [[ ! -x "$CPP_BIN" ]]; then
+    echo "ERROR: C++ binary not found at $CPP_BIN"
+    echo "Build it first: cd $CPP_DIR/build && cmake .. && make"
+    exit 1
+fi
+
+pass=0
+fail=0
+errors=()
+
+for molfile in "$MOL_DIR"/*.mol; do
+    molname="${molfile:t:r}"  # basename without extension
+    echo -n "Testing $molname ... "
+
+    # --- Rust ---
+    rust_output=$("$RUST_BIN" --extract-pathway "$molfile" 2>&1)
+    rust_index=$(echo "$rust_output" | head -1)
+    rust_dups=$(echo "$rust_output" | grep "Duplicates:" | sed 's/.*Duplicates: \([0-9]*\) (sizes: \[\(.*\)\])/\1|\2/')
+    rust_num_dups=$(echo "$rust_dups" | cut -d'|' -f1)
+    rust_dup_sizes=$(echo "$rust_dups" | cut -d'|' -f2)
+    rust_remnant=$(echo "$rust_output" | grep "Remnant edges:" | sed 's/.*Remnant edges: //')
+
+    # --- C++ ---
+    # C++ needs mol file in cwd, named without extension.
+    cp "$molfile" "$WORK_DIR/${molname}.mol"
+    (cd "$WORK_DIR" && "$CPP_BIN" "$molname" > /dev/null 2>&1)
+
+    cpp_out_file="$WORK_DIR/${molname}Out"
+    cpp_pathway_file="$WORK_DIR/${molname}Pathway"
+
+    if [[ ! -f "$cpp_out_file" ]]; then
+        echo "SKIP (C++ produced no output)"
+        continue
+    fi
+
+    cpp_index=$(grep "assembly index:" "$cpp_out_file" | sed 's/.*assembly index: //')
+
+    # Parse the C++ pathway JSON with python for robustness.
+    if [[ ! -f "$cpp_pathway_file" ]]; then
+        echo "SKIP (C++ produced no pathway)"
+        continue
+    fi
+
+    cpp_summary=$(python3 -c "
+import json, sys
+with open('$cpp_pathway_file') as f:
+    data = json.load(f)
+dups = data.get('duplicates', [])
+sizes = sorted([len(d['Left']) for d in dups], reverse=True)
+remnant_edges = len(data.get('remnant', [{}])[0].get('Edges', []))
+removed_edges = len(data.get('removed_edges', []))
+print(f'{len(dups)}|{\",\".join(str(s) for s in sizes)}|{remnant_edges + removed_edges}')
+")
+    cpp_num_dups=$(echo "$cpp_summary" | cut -d'|' -f1)
+    cpp_dup_sizes=$(echo "$cpp_summary" | cut -d'|' -f2)
+    cpp_remnant=$(echo "$cpp_summary" | cut -d'|' -f3)
+
+    # --- Compare ---
+    # Sort duplicate sizes for comparison (both should be descending already).
+    rust_sizes_sorted=$(echo "$rust_dup_sizes" | tr ',' '\n' | tr -d ' ' | sort -rn | tr '\n' ',' | sed 's/,$//')
+    cpp_sizes_sorted=$(echo "$cpp_dup_sizes" | tr ',' '\n' | tr -d ' ' | sort -rn | tr '\n' ',' | sed 's/,$//')
+
+    ok=true
+    details=""
+
+    if [[ "$rust_index" != "$cpp_index" ]]; then
+        ok=false
+        details+="  index: rust=$rust_index cpp=$cpp_index\n"
+    fi
+    if [[ "$rust_num_dups" != "$cpp_num_dups" ]]; then
+        ok=false
+        details+="  num_dups: rust=$rust_num_dups cpp=$cpp_num_dups\n"
+    fi
+    if [[ "$rust_sizes_sorted" != "$cpp_sizes_sorted" ]]; then
+        ok=false
+        details+="  dup_sizes: rust=[$rust_sizes_sorted] cpp=[$cpp_sizes_sorted]\n"
+    fi
+    if [[ "$rust_remnant" != "$cpp_remnant" ]]; then
+        ok=false
+        details+="  remnant: rust=$rust_remnant cpp=$cpp_remnant\n"
+    fi
+
+    if $ok; then
+        echo "PASS (index=$rust_index dups=$rust_num_dups sizes=[$rust_sizes_sorted] remnant=$rust_remnant)"
+        pass=$((pass + 1))
+    else
+        echo "FAIL"
+        echo -e "$details"
+        errors+=("$molname")
+        fail=$((fail + 1))
+    fi
+done
+
+echo ""
+echo "=== Results: $pass passed, $fail failed ==="
+if (( ${#errors[@]} > 0 )); then
+    echo "Failed molecules: ${errors[*]}"
+    exit 1
+fi
+
+# Clean up any C++ output files left from manual runs in the C++ directory.
+for molfile in "$MOL_DIR"/*.mol; do
+    molname="${molfile:t:r}"
+    rm -f "$CPP_DIR/${molname}Out" "$CPP_DIR/${molname}Pathway" \
+          "$CPP_DIR/${molname}.mol" "$CPP_DIR/${molname}.molOut" \
+          "$CPP_DIR/${molname}.molPathway"
+done

--- a/scripts/validate_pathways.py
+++ b/scripts/validate_pathways.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Validate alternative assembly pathways.
+
+Checks performed for each molecule:
+  1. Structural validity — every pathway step's piece_a ∪ piece_b == result,
+     and piece_a ∩ piece_b == ∅.
+  2. Distinctness — no two pathways (primary + alternatives) share the same
+     sorted match-index set.
+  3. Step count consistency — each pathway's step count equals num_duplicates
+     + remnant_edges, which should equal the assembly index.
+
+Usage:
+    python scripts/validate_pathways.py data/checks/*.mol
+    python scripts/validate_pathways.py data/gdb13_1201/*.mol --max-pathways 20
+"""
+
+import argparse
+import os
+import sys
+
+import assembly_theory as at
+
+
+def validate_pathway_steps(pathway, label="primary"):
+    """Check structural validity of a pathway's steps."""
+    errors = []
+    for i, step in enumerate(pathway):
+        a = set(step["piece_a"])
+        b = set(step["piece_b"])
+        r = set(step["result"])
+
+        if a & b:
+            errors.append(f"  [{label}] Step {i+1}: piece_a ∩ piece_b is non-empty: {a & b}")
+        if a | b != r:
+            errors.append(f"  [{label}] Step {i+1}: piece_a ∪ piece_b != result")
+    return errors
+
+
+def validate_molecule(mol_path, max_pathways=10):
+    """Run all validations on a single molecule. Returns (name, errors)."""
+    name = os.path.basename(mol_path)
+    errors = []
+
+    with open(mol_path) as f:
+        mol_block = f.read()
+
+    # Compute the index without alternatives for the ground truth.
+    try:
+        result = at.pathway_search(mol_block, alternative_pathways=True, max_pathways=max_pathways)
+    except Exception as e:
+        return name, [f"  pathway_search failed: {e}"]
+
+    index, num_matches, states_searched, pathway, alternatives, alt_match_seqs = result
+
+    if pathway is None:
+        # No duplicates found — pathway extraction is not possible.
+        # This is expected for molecules with 0 matches.
+        return name, []
+
+    # --- Check 1: structural validity of primary pathway ---
+    errors.extend(validate_pathway_steps(pathway, "primary"))
+
+    # --- Check 1b: structural validity of alternatives ---
+    if alternatives:
+        for j, alt in enumerate(alternatives):
+            errors.extend(validate_pathway_steps(alt, f"alt-{j+1}"))
+
+    # --- Check 2: step count consistency ---
+    # pathway steps == assembly index
+    if len(pathway) != index:
+        errors.append(
+            f"  Primary pathway has {len(pathway)} steps but assembly index is {index}"
+        )
+    if alternatives:
+        for j, alt in enumerate(alternatives):
+            if len(alt) != index:
+                errors.append(
+                    f"  Alt-{j+1} has {len(alt)} steps but assembly index is {index}"
+                )
+
+    # --- Check 3: distinctness via sorted match-index sets ---
+    if alternatives and alt_match_seqs:
+        # We don't have the primary match seq directly via Python API,
+        # but we can check that no two alternatives are identical.
+        seen = set()
+        for j, seq in enumerate(alt_match_seqs):
+            key = tuple(sorted(seq))
+            if key in seen:
+                errors.append(f"  Alt-{j+1} has duplicate match-set key {key}")
+            seen.add(key)
+
+    return name, errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate alternative assembly pathways")
+    parser.add_argument("molfiles", nargs="+", help="Path(s) to .mol files")
+    parser.add_argument("--max-pathways", type=int, default=10,
+                        help="Max pathways to collect (default: 10)")
+    args = parser.parse_args()
+
+    total = 0
+    passed = 0
+    failed_mols = []
+
+    for path in sorted(args.molfiles):
+        if not path.endswith(".mol"):
+            continue
+        total += 1
+        name, errors = validate_molecule(path, max_pathways=args.max_pathways)
+        if errors:
+            failed_mols.append((name, errors))
+            print(f"FAIL  {name}")
+            for e in errors:
+                print(e)
+        else:
+            passed += 1
+            print(f"OK    {name}")
+
+    print(f"\n{passed}/{total} molecules passed validation")
+    if failed_mols:
+        print(f"{len(failed_mols)} molecule(s) failed:")
+        for name, _ in failed_mols:
+            print(f"  - {name}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -19,6 +19,7 @@
 //! ```
 
 use std::{
+    collections::HashSet,
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc, Mutex,
@@ -144,6 +145,42 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
     Some(fragments)
 }
 
+/// Shared state for collecting one or more optimal assembly pathways.
+///
+/// When `max_pathways` is `None`, behaves as a single-best-pathway tracker
+/// (backward-compatible). When `Some(n)`, collects up to `n` distinct
+/// pathways that achieve the optimal assembly index, deduplicated by the
+/// *set* of match indices used (ignoring removal order).
+pub struct PathwayCollector {
+    /// Collected pathways: each is (match_sequence, leaf_fragments).
+    pub pathways: Vec<(Vec<usize>, Vec<BitSet>)>,
+    /// Set of canonical match-set keys already collected, for dedup.
+    seen_keys: HashSet<Vec<usize>>,
+    /// Maximum number of pathways to collect, or `None` for single-best mode.
+    max_pathways: Option<usize>,
+}
+
+impl PathwayCollector {
+    /// Create a new collector. `None` = single-best mode; `Some(n)` = collect
+    /// up to `n` distinct alternative pathways.
+    pub fn new(max_pathways: Option<usize>) -> Self {
+        Self {
+            pathways: Vec::new(),
+            seen_keys: HashSet::new(),
+            max_pathways,
+        }
+    }
+
+    /// Compute a canonical key for deduplication: the sorted set of match indices.
+    /// Two decompositions that remove the same set of matches (in any order)
+    /// produce identical pathways, so we deduplicate by sorted match set.
+    fn match_set_key(path: &[usize]) -> Vec<usize> {
+        let mut key = path.to_vec();
+        key.sort();
+        key
+    }
+}
+
 /// Recursive helper for [`index_search`], only public for benchmarking.
 ///
 /// Inputs:
@@ -172,7 +209,7 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
-    best_pathway: Option<&Arc<Mutex<(Vec<usize>, Vec<BitSet>)>>>,
+    best_pathway: Option<&Arc<Mutex<PathwayCollector>>>,
     path_so_far: &[usize],
 ) -> (usize, usize) {
     // If any bounds would prune this assembly state or if memoization is
@@ -245,14 +282,54 @@ pub fn recurse_index_search(
             let prev_best = best_child_index.fetch_min(child_index, Relaxed);
             let new_global = best_index.fetch_min(child_index, Relaxed);
 
-            // If this child achieved a new global best and we are tracking
-            // pathways, update the shared pathway data.
+            // If this child achieved a new global best (or tied for the best
+            // when collecting alternatives) and we are tracking pathways,
+            // update the shared pathway data.
+            //
+            // LEAF-ONLY GUARD: Only record when new_state.index() == child_index,
+            // i.e., no deeper recursion improved the index. This ensures we
+            // capture actual leaf decompositions, not intermediate ancestors
+            // that merely propagated a descendant's result.
             if let Some(bp) = best_pathway {
-                if child_index < prev_best.min(new_global) {
-                    let mut guard = bp.lock().unwrap();
-                    // Double-check: only update if still the best.
-                    if child_index <= best_index.load(Relaxed) {
-                        *guard = (child_path, new_state.fragments().clone());
+                if new_state.index() == child_index {
+                    let current_best = best_index.load(Relaxed);
+                    let is_new_best = child_index < prev_best.min(new_global);
+                    let guard_ref = bp.lock().unwrap();
+                    let is_alternative = guard_ref.max_pathways.is_some()
+                        && child_index == current_best
+                        && !is_new_best;
+                    drop(guard_ref);
+
+                    if is_new_best || is_alternative {
+                        let mut guard = bp.lock().unwrap();
+                        let current_best = best_index.load(Relaxed);
+
+                        // DUAL-MODE UPDATE:
+                        //   New best → clear all previously collected pathways
+                        //              and start fresh with this one.
+                        //   Tied best → add as an alternative if distinct and
+                        //               under the collection cap.
+                        if is_new_best && child_index <= current_best {
+                            guard.pathways.clear();
+                            guard.seen_keys.clear();
+                            let key = PathwayCollector::match_set_key(&child_path);
+                            guard.seen_keys.insert(key);
+                            guard
+                                .pathways
+                                .push((child_path, new_state.fragments().clone()));
+                        } else if child_index == current_best {
+                            // Tied with current best: add if distinct and under cap.
+                            let key = PathwayCollector::match_set_key(&child_path);
+                            let at_cap = guard
+                                .max_pathways
+                                .map_or(true, |n| guard.pathways.len() >= n);
+                            if !at_cap && !guard.seen_keys.contains(&key) {
+                                guard.seen_keys.insert(key);
+                                guard
+                                    .pathways
+                                    .push((child_path, new_state.fragments().clone()));
+                            }
+                        }
                     }
                 }
             }
@@ -302,6 +379,8 @@ pub fn recurse_index_search(
 ///   `true` and the search completes, and `None` otherwise.
 /// - The raw decomposition `(match_sequence, remnants)` if `extract_pathway`
 ///   is `true` and the search completes, and `None` otherwise.
+/// - Alternative assembly pathways as a `Vec<Vec<PathwayStep>>` if
+///   `max_pathways` is `Some` and the search completes, and `None` otherwise.
 ///
 /// # Example
 /// ```
@@ -323,7 +402,7 @@ pub fn recurse_index_search(
 ///
 /// // Compute the molecule's assembly index without parallelism, memoization,
 /// // kernelization, or bounds.
-/// let (slow_index, _, _, _, _) = index_search(
+/// let (slow_index, _, _, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -332,11 +411,12 @@ pub fn recurse_index_search(
 ///     KernelMode::None,
 ///     &[],
 ///     false,
+///     None,
 /// );
 ///
 /// // Compute the molecule's assembly index with parallelism, memoization, and
 /// // some bounds.
-/// let (fast_index, _, _, _, _) = index_search(
+/// let (fast_index, _, _, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -345,10 +425,11 @@ pub fn recurse_index_search(
 ///     KernelMode::None,
 ///     &[Bound::Log, Bound::Int],
 ///     false,
+///     None,
 /// );
 ///
 /// // Limit search to 1 ms, which should time out.
-/// let (index_bound, _, states_searched, _, _) = index_search(
+/// let (index_bound, _, states_searched, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     Some(1),
 ///     CanonizeMode::TreeNauty,
@@ -357,6 +438,7 @@ pub fn recurse_index_search(
 ///     KernelMode::None,
 ///     &[],
 ///     false,
+///     None,
 /// );
 ///
 /// assert_eq!(slow_index, 6);
@@ -374,7 +456,16 @@ pub fn index_search(
     kernel_mode: KernelMode,
     bounds: &[Bound],
     extract_pathway: bool,
-) -> (u32, u32, Option<usize>, Option<Vec<PathwayStep>>, Option<(Vec<usize>, Vec<BitSet>)>) {
+    max_pathways: Option<usize>,
+) -> (
+    u32,
+    u32,
+    Option<usize>,
+    Option<Vec<PathwayStep>>,
+    Option<(Vec<usize>, Vec<BitSet>)>,
+    Option<Vec<Vec<PathwayStep>>>,
+    Option<Vec<Vec<usize>>>,
+) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
         panic!("The chosen --kernel mode is not implemented yet!")
@@ -392,7 +483,7 @@ pub fn index_search(
 
     // Optionally create shared pathway tracking state.
     let best_pathway = if extract_pathway {
-        Some(Arc::new(Mutex::new((Vec::new(), Vec::new()))))
+        Some(Arc::new(Mutex::new(PathwayCollector::new(max_pathways))))
     } else {
         None
     };
@@ -438,26 +529,63 @@ pub fn index_search(
             _ => panic!("An unexpected error occurred in async index_search"),
         };
 
-        // Reconstruct the pathway if tracking was enabled and search completed.
-        let (pathway, decomposition) = match (&best_pathway, &states_searched) {
-            (Some(bp), Some(_)) => {
-                let guard = bp.lock().unwrap();
-                let (ref match_seq, ref remnants) = *guard;
-                if match_seq.is_empty() {
-                    (None, None)
-                } else {
-                    let mol_for_pathway = parse_mol.clone();
-                    let matches_for_pathway = Matches::new(&mol_for_pathway, canonize_mode);
-                    (
-                        Some(generate_pathway(&mol_for_pathway, &matches_for_pathway, match_seq, remnants)),
-                        Some((match_seq.clone(), remnants.clone())),
-                    )
-                }
-            }
-            _ => (None, None),
-        };
+        // Reconstruct the pathway(s) if tracking was enabled and search completed.
+        let (pathway, decomposition, alternative_pathways, alternative_decompositions) =
+            match (&best_pathway, &states_searched) {
+                (Some(bp), Some(_)) => {
+                    let guard = bp.lock().unwrap();
+                    if guard.pathways.is_empty() {
+                        (None, None, None, None)
+                    } else {
+                        let mol_for_pathway = parse_mol.clone();
+                        let matches_for_pathway = Matches::new(&mol_for_pathway, canonize_mode);
+                        let (ref match_seq, ref remnants) = guard.pathways[0];
+                        let primary = generate_pathway(
+                            &mol_for_pathway,
+                            &matches_for_pathway,
+                            match_seq,
+                            remnants,
+                        );
+                        let decomp = (match_seq.clone(), remnants.clone());
 
-        (index as u32, num_matches as u32, states_searched, pathway, decomposition)
+                        let (alt_steps, alt_seqs): (
+                            Option<Vec<Vec<PathwayStep>>>,
+                            Option<Vec<Vec<usize>>>,
+                        ) = if guard.pathways.len() > 1 {
+                            let (steps, seqs): (Vec<_>, Vec<_>) = guard.pathways[1..]
+                                .iter()
+                                .map(|(ms, rem)| {
+                                    (
+                                        generate_pathway(
+                                            &mol_for_pathway,
+                                            &matches_for_pathway,
+                                            ms,
+                                            rem,
+                                        ),
+                                        ms.clone(),
+                                    )
+                                })
+                                .unzip();
+                            (Some(steps), Some(seqs))
+                        } else {
+                            (None, None)
+                        };
+
+                        (Some(primary), Some(decomp), alt_steps, alt_seqs)
+                    }
+                }
+                _ => (None, None, None, None),
+            };
+
+        (
+            index as u32,
+            num_matches as u32,
+            states_searched,
+            pathway,
+            decomposition,
+            alternative_pathways,
+            alternative_decompositions,
+        )
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
         let (index, states_searched) = recurse_index_search(
@@ -472,20 +600,48 @@ pub fn index_search(
             &[],
         );
 
-        // Reconstruct the pathway if tracking was enabled.
-        let (pathway, decomposition) = match best_pathway {
-            Some(bp) => {
-                let guard = bp.lock().unwrap();
-                let (ref match_seq, ref remnants) = *guard;
-                (
-                    Some(generate_pathway(mol, &matches, match_seq, remnants)),
-                    Some((match_seq.clone(), remnants.clone())),
-                )
-            }
-            None => (None, None),
-        };
+        // Reconstruct the pathway(s) if tracking was enabled.
+        let (pathway, decomposition, alternative_pathways, alternative_decompositions) =
+            match best_pathway {
+                Some(bp) => {
+                    let guard = bp.lock().unwrap();
+                    if guard.pathways.is_empty() {
+                        (None, None, None, None)
+                    } else {
+                        let (ref match_seq, ref remnants) = guard.pathways[0];
+                        let primary = generate_pathway(mol, &matches, match_seq, remnants);
+                        let decomp = (match_seq.clone(), remnants.clone());
 
-        (index as u32, matches.len() as u32, Some(states_searched), pathway, decomposition)
+                        let (alt_steps, alt_seqs): (
+                            Option<Vec<Vec<PathwayStep>>>,
+                            Option<Vec<Vec<usize>>>,
+                        ) = if guard.pathways.len() > 1 {
+                            let (steps, seqs): (Vec<_>, Vec<_>) = guard.pathways[1..]
+                                .iter()
+                                .map(|(ms, rem)| {
+                                    (generate_pathway(mol, &matches, ms, rem), ms.clone())
+                                })
+                                .unzip();
+                            (Some(steps), Some(seqs))
+                        } else {
+                            (None, None)
+                        };
+
+                        (Some(primary), Some(decomp), alt_steps, alt_seqs)
+                    }
+                }
+                None => (None, None, None, None),
+            };
+
+        (
+            index as u32,
+            matches.len() as u32,
+            Some(states_searched),
+            pathway,
+            decomposition,
+            alternative_pathways,
+            alternative_decompositions,
+        )
     }
 }
 
@@ -521,6 +677,7 @@ pub fn index(mol: &Molecule) -> u32 {
         KernelMode::None,
         &[Bound::Int, Bound::MatchableEdges],
         false,
+        None,
     )
     .0
 }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -21,7 +21,7 @@
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
-        Arc,
+        Arc, Mutex,
     },
     time::Duration,
 };
@@ -38,6 +38,7 @@ use crate::{
     matches::Matches,
     memoize::{Cache, MemoizeMode},
     molecule::Molecule,
+    pathway::{generate_pathway, PathwayStep},
     state::State,
     utils::connected_components_under_edges,
 };
@@ -153,6 +154,10 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
 /// - `bounds`: The list of bounding strategies to apply.
 /// - `cache`: Memoization cache storing previously searched assembly states.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
+/// - `best_pathway`: When `Some`, tracks the `(match_ix_sequence, leaf_fragments)`
+///    for the best decomposition path found so far. When `None`, pathway tracking
+///    is skipped entirely.
+/// - `path_so_far`: The sequence of match indices removed from root to this state.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: An updated upper bound on the assembly index. (Note: If this
@@ -167,6 +172,8 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
+    best_pathway: Option<&Arc<Mutex<(Vec<usize>, Vec<BitSet>)>>>,
+    path_so_far: &[usize],
 ) -> (usize, usize) {
     // If any bounds would prune this assembly state or if memoization is
     // enabled and this assembly state is preempted by the cached state, halt.
@@ -199,21 +206,57 @@ pub fn recurse_index_search(
                 parallel_mode
             };
 
+            // Build the extended path for this child.
+            let child_path: Vec<usize> = if best_pathway.is_some() {
+                let mut p = path_so_far.to_vec();
+                p.push(match_ix);
+                p
+            } else {
+                Vec::new()
+            };
+
+            let new_state = state.update(fragments, i, match_ix, h1.len());
+
+            // If this is a leaf state (no more matches can be removed) and we
+            // are tracking pathways, check if this is the new best.
+            if best_pathway.is_some() {
+                let child_index = new_state.index();
+                if child_index < best_index.load(Relaxed) {
+                    // This will be checked again after recursion, but for leaf
+                    // states we capture here.
+                }
+            }
+
             // Recurse using the remaining matches and updated fragments.
             let (child_index, child_states_searched) = recurse_index_search(
                 mol,
                 matches,
-                &state.update(fragments, i, match_ix, h1.len()),
+                &new_state,
                 best_index.clone(),
                 bounds,
                 &mut cache.clone(),
                 new_parallel,
+                best_pathway,
+                &child_path,
             );
 
             // Update the best assembly indices (across children states and the
             // entire search) and the number of descendant states searched.
-            best_child_index.fetch_min(child_index, Relaxed);
-            best_index.fetch_min(best_child_index.load(Relaxed), Relaxed);
+            let prev_best = best_child_index.fetch_min(child_index, Relaxed);
+            let new_global = best_index.fetch_min(child_index, Relaxed);
+
+            // If this child achieved a new global best and we are tracking
+            // pathways, update the shared pathway data.
+            if let Some(bp) = best_pathway {
+                if child_index < prev_best.min(new_global) {
+                    let mut guard = bp.lock().unwrap();
+                    // Double-check: only update if still the best.
+                    if child_index <= best_index.load(Relaxed) {
+                        *guard = (child_path, new_state.fragments().clone());
+                    }
+                }
+            }
+
             states_searched.fetch_add(child_states_searched, Relaxed);
         }
     };
@@ -255,6 +298,10 @@ pub fn recurse_index_search(
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
+/// - The assembly pathway as a `Vec<PathwayStep>` if `extract_pathway` is
+///   `true` and the search completes, and `None` otherwise.
+/// - The raw decomposition `(match_sequence, remnants)` if `extract_pathway`
+///   is `true` and the search completes, and `None` otherwise.
 ///
 /// # Example
 /// ```
@@ -276,7 +323,7 @@ pub fn recurse_index_search(
 ///
 /// // Compute the molecule's assembly index without parallelism, memoization,
 /// // kernelization, or bounds.
-/// let (slow_index, _, _) = index_search(
+/// let (slow_index, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -284,11 +331,12 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     false,
 /// );
 ///
 /// // Compute the molecule's assembly index with parallelism, memoization, and
 /// // some bounds.
-/// let (fast_index, _, _) = index_search(
+/// let (fast_index, _, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -296,10 +344,11 @@ pub fn recurse_index_search(
 ///     MemoizeMode::CanonIndex,
 ///     KernelMode::None,
 ///     &[Bound::Log, Bound::Int],
+///     false,
 /// );
 ///
 /// // Limit search to 1 ms, which should time out.
-/// let (index_bound, _, states_searched) = index_search(
+/// let (index_bound, _, states_searched, _, _) = index_search(
 ///     &anthracene,
 ///     Some(1),
 ///     CanonizeMode::TreeNauty,
@@ -307,6 +356,7 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     false,
 /// );
 ///
 /// assert_eq!(slow_index, 6);
@@ -323,7 +373,8 @@ pub fn index_search(
     memoize_mode: MemoizeMode,
     kernel_mode: KernelMode,
     bounds: &[Bound],
-) -> (u32, u32, Option<usize>) {
+    extract_pathway: bool,
+) -> (u32, u32, Option<usize>, Option<Vec<PathwayStep>>, Option<(Vec<usize>, Vec<BitSet>)>) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
         panic!("The chosen --kernel mode is not implemented yet!")
@@ -339,12 +390,21 @@ pub fn index_search(
     // Use an `Arc` to track the best assembly index across parallel threads.
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
 
+    // Optionally create shared pathway tracking state.
+    let best_pathway = if extract_pathway {
+        Some(Arc::new(Mutex::new((Vec::new(), Vec::new()))))
+    } else {
+        None
+    };
+
     // Search for the shortest assembly pathway recursively.
     if let Some(timeout) = timeout {
         // If a timeout is provided, we will search within an asynchronous task
         // that can be interrupted after the specified duration (see below). To
         // avoid subsequent scope issues, make copies of various variables.
         let best_index_copy = best_index.clone();
+        let best_pathway_copy = best_pathway.clone();
+        let parse_mol = mol.clone();
         let mol = mol.clone();
         let bounds = bounds.to_vec();
         let num_matches = matches.len();
@@ -362,6 +422,8 @@ pub fn index_search(
                     &bounds,
                     &mut cache,
                     parallel_mode,
+                    best_pathway_copy.as_ref(),
+                    &[],
                 ));
             });
             tktimeout(Duration::from_millis(timeout), recv).await
@@ -375,7 +437,27 @@ pub fn index_search(
             Err(_) => (best_index.load(Relaxed), None),
             _ => panic!("An unexpected error occurred in async index_search"),
         };
-        (index as u32, num_matches as u32, states_searched)
+
+        // Reconstruct the pathway if tracking was enabled and search completed.
+        let (pathway, decomposition) = match (&best_pathway, &states_searched) {
+            (Some(bp), Some(_)) => {
+                let guard = bp.lock().unwrap();
+                let (ref match_seq, ref remnants) = *guard;
+                if match_seq.is_empty() {
+                    (None, None)
+                } else {
+                    let mol_for_pathway = parse_mol.clone();
+                    let matches_for_pathway = Matches::new(&mol_for_pathway, canonize_mode);
+                    (
+                        Some(generate_pathway(&mol_for_pathway, &matches_for_pathway, match_seq, remnants)),
+                        Some((match_seq.clone(), remnants.clone())),
+                    )
+                }
+            }
+            _ => (None, None),
+        };
+
+        (index as u32, num_matches as u32, states_searched, pathway, decomposition)
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
         let (index, states_searched) = recurse_index_search(
@@ -386,8 +468,24 @@ pub fn index_search(
             bounds,
             &mut cache,
             parallel_mode,
+            best_pathway.as_ref(),
+            &[],
         );
-        (index as u32, matches.len() as u32, Some(states_searched))
+
+        // Reconstruct the pathway if tracking was enabled.
+        let (pathway, decomposition) = match best_pathway {
+            Some(bp) => {
+                let guard = bp.lock().unwrap();
+                let (ref match_seq, ref remnants) = *guard;
+                (
+                    Some(generate_pathway(mol, &matches, match_seq, remnants)),
+                    Some((match_seq.clone(), remnants.clone())),
+                )
+            }
+            None => (None, None),
+        };
+
+        (index as u32, matches.len() as u32, Some(states_searched), pathway, decomposition)
     }
 }
 
@@ -422,6 +520,7 @@ pub fn index(mol: &Molecule) -> u32 {
         MemoizeMode::CanonIndex,
         KernelMode::None,
         &[Bound::Int, Bound::MatchableEdges],
+        false,
     )
     .0
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod kernels;
 pub mod matches;
 pub mod memoize;
 mod nauty;
+pub mod pathway;
 pub mod state;
 mod vf3;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,16 @@ struct Cli {
     /// Extract and print the assembly pathway (bottom-up reconstruction).
     #[arg(long)]
     extract_pathway: bool,
+
+    /// Collect and print alternative assembly pathways that use different
+    /// duplicates/remnants. Implies --extract-pathway.
+    #[arg(long)]
+    alternative_pathways: bool,
+
+    /// Maximum number of alternative pathways to collect (default: 10).
+    /// Only meaningful with --alternative-pathways.
+    #[arg(long, default_value_t = 10)]
+    max_pathways: usize,
 }
 
 #[derive(Args, Debug)]
@@ -115,7 +125,21 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, num_matches, states_searched, pathway, decomposition) = index_search(
+    let extract = cli.extract_pathway || cli.alternative_pathways;
+    let max_pathways = if cli.alternative_pathways {
+        Some(cli.max_pathways)
+    } else {
+        None
+    };
+    let (
+        index,
+        num_matches,
+        states_searched,
+        pathway,
+        decomposition,
+        alternative_pathways,
+        _alternative_decompositions,
+    ) = index_search(
         &mol,
         cli.timeout,
         cli.canonize,
@@ -123,7 +147,8 @@ fn main() -> Result<()> {
         cli.memoize,
         cli.kernel,
         boundlist,
-        cli.extract_pathway,
+        extract,
+        max_pathways,
     );
 
     // Print final output, depending on --verbose.
@@ -180,8 +205,29 @@ fn main() -> Result<()> {
             .map(|&mix| matches.match_fragments(mix).0.len())
             .collect();
         println!("\n  Summary:");
-        println!("    Duplicates: {} (sizes: {:?})", dup_sizes.len(), dup_sizes);
+        println!(
+            "    Duplicates: {} (sizes: {:?})",
+            dup_sizes.len(),
+            dup_sizes
+        );
         println!("    Remnant edges: {}", present.len());
+    }
+
+    // Print alternative pathways if collected. These are distinct optimal
+    // decompositions (same assembly index, different set of duplicates used).
+    if let Some(ref alternatives) = alternative_pathways {
+        let total = alternatives.len();
+        for (idx, steps) in alternatives.iter().enumerate() {
+            println!(
+                "\nAlternative Pathway {}/{} ({} steps):",
+                idx + 1,
+                total,
+                steps.len()
+            );
+            for (i, step) in steps.iter().enumerate() {
+                println!("  Step {}: {}", i + 1, step);
+            }
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use assembly_theory::{
     canonize::CanonizeMode,
     kernels::KernelMode,
     loader::parse_molfile_str,
+    matches::Matches,
     memoize::MemoizeMode,
+    pathway::edges_as_vertex_pairs,
 };
 use clap::{Args, Parser};
 
@@ -56,6 +58,10 @@ struct Cli {
     /// Strategy for performing graph kernelization during the search phase.
     #[arg(long, value_enum, default_value_t = KernelMode::None)]
     kernel: KernelMode,
+
+    /// Extract and print the assembly pathway (bottom-up reconstruction).
+    #[arg(long)]
+    extract_pathway: bool,
 }
 
 #[derive(Args, Debug)]
@@ -109,7 +115,7 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, num_matches, states_searched) = index_search(
+    let (index, num_matches, states_searched, pathway, decomposition) = index_search(
         &mol,
         cli.timeout,
         cli.canonize,
@@ -117,6 +123,7 @@ fn main() -> Result<()> {
         cli.memoize,
         cli.kernel,
         boundlist,
+        cli.extract_pathway,
     );
 
     // Print final output, depending on --verbose.
@@ -139,6 +146,42 @@ fn main() -> Result<()> {
         (false, None) => {
             println!("<= {index} (timed out)");
         }
+    }
+
+    // Print the assembly pathway if extracted.
+    if let Some(ref steps) = pathway {
+        println!("\nAssembly Pathway ({} steps):", steps.len());
+        for (i, step) in steps.iter().enumerate() {
+            println!("  Step {}: {}", i + 1, step);
+        }
+    }
+
+    // Print the raw decomposition (C++ comparable) if available.
+    if let Some((ref match_seq, _)) = decomposition {
+        let matches = Matches::new(&mol, cli.canonize);
+        println!("\nDecomposition (duplicates largest-first):");
+        for &mix in match_seq.iter() {
+            let (h1, h2) = matches.match_fragments(mix);
+            let left = edges_as_vertex_pairs(&mol, h1);
+            let right = edges_as_vertex_pairs(&mol, h2);
+            println!("  Left:  {:?}", left);
+            println!("  Right: {:?}", right);
+        }
+        let mut present = bit_set::BitSet::with_capacity(mol.graph().edge_count());
+        present.extend(mol.graph().edge_indices().map(|ix| ix.index()));
+        for &mix in match_seq.iter() {
+            let (_, h2) = matches.match_fragments(mix);
+            present.difference_with(h2);
+        }
+        println!("  Remnant: {:?}", edges_as_vertex_pairs(&mol, &present));
+
+        let dup_sizes: Vec<usize> = match_seq
+            .iter()
+            .map(|&mix| matches.match_fragments(mix).0.len())
+            .collect();
+        println!("\n  Summary:");
+        println!("    Duplicates: {} (sizes: {:?})", dup_sizes.len(), dup_sizes);
+        println!("    Remnant edges: {}", present.len());
     }
 
     Ok(())

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,0 +1,219 @@
+//! Assembly pathway reconstruction from top-down decomposition results.
+//!
+//! Implements the `Generate_Pathway` algorithm from the supplementary
+//! information of [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964).
+
+use std::fmt;
+
+use bit_set::BitSet;
+use petgraph::graph::EdgeIndex;
+
+use crate::{matches::Matches, molecule::Molecule};
+
+/// Format an edge set as a list of `(src, dst)` vertex pairs.
+pub fn edges_as_vertex_pairs(mol: &Molecule, edges: &BitSet) -> Vec<(usize, usize)> {
+    edges
+        .iter()
+        .map(|e| {
+            let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+            (src.index(), dst.index())
+        })
+        .collect()
+}
+
+/// A single step in an assembly pathway: joining two pieces into one.
+#[derive(Debug, Clone)]
+pub struct PathwayStep {
+    /// First piece being joined (edge set).
+    pub piece_a: BitSet,
+    /// Second piece being joined (edge set).
+    pub piece_b: BitSet,
+    /// The result of joining the two pieces (union of edge sets).
+    pub result: BitSet,
+}
+
+impl fmt::Display for PathwayStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let a: Vec<usize> = self.piece_a.iter().collect();
+        let b: Vec<usize> = self.piece_b.iter().collect();
+        let r: Vec<usize> = self.result.iter().collect();
+        write!(f, "{:?} + {:?} -> {:?}", a, b, r)
+    }
+}
+
+/// Check whether two edge sets share at least one node (vertex) in the
+/// molecular graph.
+fn shares_node(mol: &Molecule, a: &BitSet, b: &BitSet) -> bool {
+    let mut nodes_a = BitSet::with_capacity(mol.graph().node_count());
+    for e in a {
+        let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+        nodes_a.insert(src.index());
+        nodes_a.insert(dst.index());
+    }
+    for e in b {
+        let (src, dst) = mol.graph().edge_endpoints(EdgeIndex::new(e)).unwrap();
+        if nodes_a.contains(src.index()) || nodes_a.contains(dst.index()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// `Consistent_Join`: merge any two pieces sharing a vertex, recording each
+/// join as a pathway step. Returns `true` if any join was performed.
+fn consistent_join(mol: &Molecule, pieces: &mut Vec<BitSet>, steps: &mut Vec<PathwayStep>) -> bool {
+    let mut joined = false;
+    let mut i = 0;
+    while i < pieces.len() {
+        let mut j = i + 1;
+        let mut did_join = false;
+        while j < pieces.len() {
+            if shares_node(mol, &pieces[i], &pieces[j]) {
+                // Join pieces[j] into pieces[i].
+                let piece_a = pieces[i].clone();
+                let piece_b = pieces.swap_remove(j);
+                pieces[i].union_with(&piece_b);
+                steps.push(PathwayStep {
+                    piece_a,
+                    piece_b,
+                    result: pieces[i].clone(),
+                });
+                joined = true;
+                did_join = true;
+                // Don't increment j — a new element may have been swapped in.
+            } else {
+                j += 1;
+            }
+        }
+        if !did_join {
+            i += 1;
+        }
+        // If we joined, re-check pieces[i] against remaining pieces.
+    }
+    joined
+}
+
+/// Find pieces that overlap with a given fragment (by shared nodes).
+fn filter_pieces(mol: &Molecule, pieces: &[BitSet], fragment: &BitSet) -> Vec<usize> {
+    pieces
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| shares_node(mol, p, fragment))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// `Duplicate_Construction`: process duplicates (matched fragment pairs) from
+/// smallest to largest, adding copies or first reassembling containing pieces.
+fn duplicate_construction(
+    mol: &Molecule,
+    duplicates: &[(BitSet, BitSet)],
+    pieces: &mut Vec<BitSet>,
+    steps: &mut Vec<PathwayStep>,
+) {
+    for (h1, h2) in duplicates {
+        // Check if h2 (the "template") is already exactly one of the pieces.
+        let exact_match = pieces.iter().position(|p| p == h2);
+        if let Some(_) = exact_match {
+            // The template is already a piece; just add the copy.
+            pieces.push(h1.clone());
+        } else {
+            // Filter pieces that overlap with h2.
+            let filtered_ixs = filter_pieces(mol, pieces, h2);
+            if filtered_ixs.is_empty() {
+                // Template edges are already part of a larger assembled piece;
+                // just add the copy.
+                pieces.push(h1.clone());
+                continue;
+            }
+
+            // Extract filtered pieces and remove them from the main list.
+            // Remove in reverse index order to avoid invalidating indices.
+            let mut filtered: Vec<BitSet> = Vec::new();
+            let mut sorted_ixs = filtered_ixs;
+            sorted_ixs.sort_unstable_by(|a, b| b.cmp(a));
+            for ix in &sorted_ixs {
+                filtered.push(pieces.swap_remove(*ix));
+            }
+
+            // Join the filtered pieces until they form one piece.
+            while filtered.len() > 1 {
+                if !consistent_join(mol, &mut filtered, steps) {
+                    break;
+                }
+            }
+
+            // Add both the reassembled piece and the duplicate copy.
+            pieces.extend(filtered);
+            pieces.push(h1.clone());
+        }
+    }
+}
+
+/// Reconstruct the bottom-up assembly pathway from the top-down decomposition
+/// results.
+///
+/// # Arguments
+/// - `mol`: The molecule.
+/// - `matches`: The matches structure used during the search.
+/// - `match_sequence`: The sequence of global `match_ix` values from root to
+///   leaf of the optimal decomposition path.
+/// - `remnants`: The leaf state's fragments (the pieces left after all
+///   duplicates have been removed). Note: these may exclude singleton (single-
+///   edge) fragments that were dropped during the search.
+///
+/// # Returns
+/// A vector of [`PathwayStep`]s representing the assembly pathway from basic
+/// fragments to the complete molecule.
+pub fn generate_pathway(
+    mol: &Molecule,
+    matches: &Matches,
+    match_sequence: &[usize],
+    _remnants: &[BitSet],
+) -> Vec<PathwayStep> {
+    let mut steps: Vec<PathwayStep> = Vec::new();
+
+    // Build the list of duplicates from the match sequence. Each duplicate is
+    // (copy, template): the search kept h1 (template) and discarded h2 (copy).
+    // For bottom-up reconstruction, we reverse so smallest fragments come first.
+    let mut duplicates: Vec<(BitSet, BitSet)> = match_sequence
+        .iter()
+        .map(|&mix| {
+            let (h1, h2) = matches.match_fragments(mix);
+            (h2.clone(), h1.clone()) // (copy, template)
+        })
+        .collect();
+    duplicates.reverse();
+
+    // Compute the edges present at the leaf level: all molecule edges minus
+    // the net-removed edges (h2 from each decomposition step).
+    let mut present_edges = BitSet::with_capacity(mol.graph().edge_count());
+    present_edges.extend(mol.graph().edge_indices().map(|ix| ix.index()));
+    for &mix in match_sequence.iter() {
+        let (_, h2) = matches.match_fragments(mix);
+        present_edges.difference_with(h2);
+    }
+
+    // Start pieces as individual edges (basic units).
+    let mut pieces: Vec<BitSet> = present_edges
+        .iter()
+        .map(|e| {
+            let mut bs = BitSet::with_capacity(mol.graph().edge_count());
+            bs.insert(e);
+            bs
+        })
+        .collect();
+
+    // Process duplicates: for each one, reassemble its template from basic
+    // pieces if needed, then add the copy.
+    duplicate_construction(mol, &duplicates, &mut pieces, &mut steps);
+
+    // Iteratively join remaining pieces that share vertices.
+    loop {
+        if !consistent_join(mol, &mut pieces, &mut steps) {
+            break;
+        }
+    }
+
+    steps
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -449,7 +449,7 @@ pub fn _index_search(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    let (idx, num_matches, states_searched, _, _) = index_search(
+    let (idx, num_matches, states_searched, _, _, _, _) = index_search(
         &mol,
         timeout,
         canonize_mode,
@@ -458,6 +458,7 @@ pub fn _index_search(
         kernel_mode,
         &boundlist,
         false,
+        None,
     );
     Ok((idx, num_matches, states_searched))
 }
@@ -505,9 +506,13 @@ pub fn _index_search(
 ///
 /// for step in pathway:
 ///     print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
+///
+/// # Collect alternative pathways.
+/// (index, num_matches, states_searched, pathway, alternatives) = at.pathway_search(
+///     mol_block, alternative_pathways=True, max_pathways=5)
 /// ```
 #[pyfunction(name = "pathway_search")]
-#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()]), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"]))")]
+#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()], alternative_pathways=false, max_pathways=10), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"], alternative_pathways=False, max_pathways=10)")]
 pub fn _pathway_search(
     mol_block: &str,
     timeout: Option<u64>,
@@ -516,7 +521,9 @@ pub fn _pathway_search(
     memoize_str: &str,
     kernel_str: &str,
     bound_strs: Vec<String>,
-) -> PyResult<(u32, u32, Option<usize>, Option<Vec<HashMap<String, Vec<usize>>>>)> {
+    alternative_pathways: bool,
+    max_pathways: usize,
+) -> PyResult<PyObject> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol = parse_molfile_str(mol_block)?;
 
@@ -549,33 +556,80 @@ pub fn _pathway_search(
     let pybounds = process_bound_strs(bound_strs)?;
     let boundlist = make_boundlist(&pybounds);
 
-    // Compute assembly index with pathway extraction.
-    let (idx, num_matches, states_searched, pathway, _) = index_search(
-        &mol,
-        timeout,
-        canonize_mode,
-        parallel_mode,
-        memoize_mode,
-        kernel_mode,
-        &boundlist,
-        true,
-    );
+    // When alternative_pathways=True, pass max_pathways to enable collection;
+    // otherwise None triggers single-best-pathway mode.
+    let max_pw = if alternative_pathways {
+        Some(max_pathways)
+    } else {
+        None
+    };
+    let (idx, num_matches, states_searched, pathway, _, alt_pathways, alt_decompositions) =
+        index_search(
+            &mol,
+            timeout,
+            canonize_mode,
+            parallel_mode,
+            memoize_mode,
+            kernel_mode,
+            &boundlist,
+            true,
+            max_pw,
+        );
 
     // Convert pathway steps to Python-friendly dicts.
-    let py_pathway = pathway.map(|steps| {
+    let py_pathway: Option<Vec<HashMap<String, Vec<usize>>>> = pathway.map(|steps| {
         steps
             .iter()
             .map(|step| {
-                let mut d = HashMap::new();
+                let mut d: HashMap<String, Vec<usize>> = HashMap::new();
                 d.insert("piece_a".to_string(), step.piece_a.iter().collect());
                 d.insert("piece_b".to_string(), step.piece_b.iter().collect());
                 d.insert("result".to_string(), step.result.iter().collect());
                 d
             })
-            .collect()
+            .collect::<Vec<_>>()
     });
 
-    Ok((idx, num_matches, states_searched, py_pathway))
+    // Return type depends on mode:
+    //   default:              4-tuple (index, num_matches, states, pathway)
+    //   alternative_pathways: 6-tuple adding (alt_pathways, alt_match_seqs)
+    Python::with_gil(|py| {
+        if alternative_pathways {
+            let py_alternatives: Option<Vec<Vec<HashMap<String, Vec<usize>>>>> =
+                alt_pathways.map(|pathways| {
+                    pathways
+                        .iter()
+                        .map(|steps| {
+                            steps
+                                .iter()
+                                .map(|step| {
+                                    let mut d = HashMap::new();
+                                    d.insert("piece_a".to_string(), step.piece_a.iter().collect());
+                                    d.insert("piece_b".to_string(), step.piece_b.iter().collect());
+                                    d.insert("result".to_string(), step.result.iter().collect());
+                                    d
+                                })
+                                .collect()
+                        })
+                        .collect()
+                });
+            let py_alt_match_seqs: Option<Vec<Vec<usize>>> = alt_decompositions;
+            Ok((
+                idx,
+                num_matches,
+                states_searched,
+                py_pathway,
+                py_alternatives,
+                py_alt_match_seqs,
+            )
+                .into_pyobject(py)?
+                .into())
+        } else {
+            Ok((idx, num_matches, states_searched, py_pathway)
+                .into_pyobject(py)?
+                .into())
+        }
+    })
 }
 
 /// A Python wrapper for the assembly_theory Rust crate.

--- a/src/python.rs
+++ b/src/python.rs
@@ -60,6 +60,7 @@
 //! at.index(mol_block)  # 6
 //! ```
 
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use pyo3::{
@@ -448,7 +449,7 @@ pub fn _index_search(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    Ok(index_search(
+    let (idx, num_matches, states_searched, _, _) = index_search(
         &mol,
         timeout,
         canonize_mode,
@@ -456,7 +457,125 @@ pub fn _index_search(
         memoize_mode,
         kernel_mode,
         &boundlist,
-    ))
+        false,
+    );
+    Ok((idx, num_matches, states_searched))
+}
+
+/// Computes a molecule's assembly index and extracts the assembly pathway
+/// using a top-down recursive search, parameterized by the specified options.
+///
+/// Python version of [`index_search`] with pathway extraction enabled.
+///
+/// # Python Parameters
+///
+/// - `mol_block`: The contents of a `.mol` file as a `str`.
+/// - `timeout`: An `int` duration in milliseconds after which search is
+/// stopped, or `None` if search is run until the true assembly index is found.
+/// - `canonize_str`: A canonization mode from [`"nauty"`, `"faulon"`,
+/// `"tree-nauty"` (default), `"tree-faulon"`].
+/// - `parallel_str`: A parallelization mode from [`"none"`, `"depth-one"`
+/// (default), `"always"`].
+/// - `memoize_str`: A memoization mode from [`none`, `canon-index` (default)].
+/// - `kernel_str`: A kernelization mode from [`"none"` (default), `"once"`,
+/// `"depth-one"`, `"always"`].
+/// - `bound_strs`: A list of bounds. Default: `["int", "matchable-edges"]`.
+///
+/// # Python Returns
+///
+/// A 4-tuple containing:
+/// - The molecule's `int` assembly index (or an upper bound if timed out).
+/// - The molecule's `int` number of edge-disjoint isomorphic subgraph pairs.
+/// - The `int` number of assembly states searched, or `None` if timed out.
+/// - A `list` of pathway steps, where each step is a dict with keys
+///   `"piece_a"`, `"piece_b"`, and `"result"` (each a list of edge indices),
+///   or `None` if timed out.
+///
+/// # Python Example
+///
+/// ```custom,{class=language-python}
+/// import assembly_theory as at
+///
+/// # Load a mol block from file.
+/// with open('data/checks/benzene.mol') as f:
+///     mol_block = f.read()
+///
+/// # Calculate the molecule's assembly index and extract pathway.
+/// (index, num_matches, states_searched, pathway) = at.pathway_search(mol_block)
+///
+/// for step in pathway:
+///     print(f"{step['piece_a']} + {step['piece_b']} -> {step['result']}")
+/// ```
+#[pyfunction(name = "pathway_search")]
+#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()]), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"]))")]
+pub fn _pathway_search(
+    mol_block: &str,
+    timeout: Option<u64>,
+    canonize_str: &str,
+    parallel_str: &str,
+    memoize_str: &str,
+    kernel_str: &str,
+    bound_strs: Vec<String>,
+) -> PyResult<(u32, u32, Option<usize>, Option<Vec<HashMap<String, Vec<usize>>>>)> {
+    // Parse the .mol file contents as a molecule::Molecule.
+    let mol = parse_molfile_str(mol_block)?;
+
+    // Parse the various modes and bound options.
+    let canonize_mode = match PyCanonizeMode::from_str(canonize_str) {
+        Ok(PyCanonizeMode::Nauty) => CanonizeMode::Nauty,
+        Ok(PyCanonizeMode::Faulon) => CanonizeMode::Faulon,
+        Ok(PyCanonizeMode::TreeNauty) => CanonizeMode::TreeNauty,
+        Ok(PyCanonizeMode::TreeFaulon) => CanonizeMode::TreeFaulon,
+        Err(e) => return Err(e),
+    };
+    let parallel_mode = match PyParallelMode::from_str(parallel_str) {
+        Ok(PyParallelMode::None) => ParallelMode::None,
+        Ok(PyParallelMode::DepthOne) => ParallelMode::DepthOne,
+        Ok(PyParallelMode::Always) => ParallelMode::Always,
+        Err(e) => return Err(e),
+    };
+    let memoize_mode = match PyMemoizeMode::from_str(memoize_str) {
+        Ok(PyMemoizeMode::None) => MemoizeMode::None,
+        Ok(PyMemoizeMode::CanonIndex) => MemoizeMode::CanonIndex,
+        Err(e) => return Err(e),
+    };
+    let kernel_mode = match PyKernelMode::from_str(kernel_str) {
+        Ok(PyKernelMode::None) => KernelMode::None,
+        Ok(PyKernelMode::Once) => KernelMode::Once,
+        Ok(PyKernelMode::DepthOne) => KernelMode::DepthOne,
+        Ok(PyKernelMode::Always) => KernelMode::Always,
+        Err(e) => return Err(e),
+    };
+    let pybounds = process_bound_strs(bound_strs)?;
+    let boundlist = make_boundlist(&pybounds);
+
+    // Compute assembly index with pathway extraction.
+    let (idx, num_matches, states_searched, pathway, _) = index_search(
+        &mol,
+        timeout,
+        canonize_mode,
+        parallel_mode,
+        memoize_mode,
+        kernel_mode,
+        &boundlist,
+        true,
+    );
+
+    // Convert pathway steps to Python-friendly dicts.
+    let py_pathway = pathway.map(|steps| {
+        steps
+            .iter()
+            .map(|step| {
+                let mut d = HashMap::new();
+                d.insert("piece_a".to_string(), step.piece_a.iter().collect());
+                d.insert("piece_b".to_string(), step.piece_b.iter().collect());
+                d.insert("result".to_string(), step.result.iter().collect());
+                d
+            })
+            .collect()
+    });
+
+    Ok((idx, num_matches, states_searched, py_pathway))
 }
 
 /// A Python wrapper for the assembly_theory Rust crate.
@@ -468,5 +587,6 @@ fn _assembly_theory(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(_depth, m)?)?;
     m.add_function(wrap_pyfunction!(_index, m)?)?;
     m.add_function(wrap_pyfunction!(_index_search, m)?)?;
+    m.add_function(wrap_pyfunction!(_pathway_search, m)?)?;
     Ok(())
 }

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -71,7 +71,7 @@ fn test_reference_dataset(
         .expect(&format!("Failed to parse {name:?}"));
 
         // Calculate the molecule's assembly index.
-        let (index, _, _, _, _) = index_search(
+        let (index, _, _, _, _, _, _) = index_search(
             &mol,
             None,
             canonize_mode,
@@ -80,6 +80,7 @@ fn test_reference_dataset(
             kernel_mode,
             bounds,
             false,
+            None,
         );
 
         // Compare calculated assembly index to ground truth.

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -71,7 +71,7 @@ fn test_reference_dataset(
         .expect(&format!("Failed to parse {name:?}"));
 
         // Calculate the molecule's assembly index.
-        let (index, _, _) = index_search(
+        let (index, _, _, _, _) = index_search(
             &mol,
             None,
             canonize_mode,
@@ -79,6 +79,7 @@ fn test_reference_dataset(
             memoize_mode,
             kernel_mode,
             bounds,
+            false,
         );
 
         // Compare calculated assembly index to ground truth.


### PR DESCRIPTION
Pull request as discussed, implementing searching for alternative pathways, written with the help of Claude.

Builds on #146.

Description:

- touches mostly `assembly.rs` (+181) and `main.rs` (+45)
- adds new CLI arg `--alternative-pathways`
- updates Python module implementation
- validates through internal consistency checks
- passes existing tests and shows no regression
- updates `README.md` and existing tests/benchmarks