### PR TITLE
Remove unnecessary Option from assembly::fragments

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -96,17 +96,20 @@ pub fn depth(mol: &Molecule) -> u32 {
     ix
 }
 
-/// Determine the fragments produced from the given assembly state by removing
-/// the given pair of edge-disjoint, isomorphic subgraphs and then adding one
-/// back; return `None` if not possible.
-fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Option<Vec<BitSet>> {
-    // Attempt to find fragments f1 and f2 containing h1 and h2, respectively;
-    // if either do not exist, exit without further fragmentation.
-    let f1 = state.iter().enumerate().find(|(_, c)| h1.is_subset(c));
-    let f2 = state.iter().enumerate().find(|(_, c)| h2.is_subset(c));
-    let (Some((i1, f1)), Some((i2, f2))) = (f1, f2) else {
-        return None;
-    };
+/// Find all fragments in the given assembly state after removing the given
+/// pair of edge-disjoint, isomorphic subgraphs and then adding one back.
+fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<BitSet> {
+    // Find fragments f1 and f2 containing h1 and h2, respectively.
+    let (i1, f1) = state
+        .iter()
+        .enumerate()
+        .find(|(_, c)| h1.is_subset(c))
+        .unwrap();
+    let (i2, f2) = state
+        .iter()
+        .enumerate()
+        .find(|(_, c)| h2.is_subset(c))
+        .unwrap();
 
     let mut fragments = state.to_owned();
 
@@ -117,9 +120,9 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
     if i1 == i2 {
         let mut union = h1.clone();
         union.union_with(h2);
-        let mut difference = f1.clone();
-        difference.difference_with(&union);
-        let c = connected_components_under_edges(mol.graph(), &difference);
+        let mut diff = f1.clone();
+        diff.difference_with(&union);
+        let c = connected_components_under_edges(mol.graph(), &diff);
         fragments.extend(c);
         fragments.swap_remove(i1);
     } else {
@@ -140,7 +143,7 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Opti
     // Drop any singleton fragments, add h1 as a fragment, and return.
     fragments.retain(|i| i.len() > 1);
     fragments.push(h1.clone());
-    Some(fragments)
+    fragments
 }
 
 /// Recursive helper for [`index_search`], only public for benchmarking.
@@ -184,29 +187,26 @@ pub fn recurse_index_search(
     // the given match.
     let recurse_on_match = |match_ix: usize| -> (usize, usize) {
         let (h1, h2) = matches.match_fragments(match_ix);
+        let fragments = fragments(mol, &intermediate_frags, h1, h2);
 
-        if let Some(fragments) = fragments(mol, &intermediate_frags, h1, h2) {
-            // If using depth-one parallelism, all descendant states should be
-            // computed serially.
-            let new_parallel = if parallel_mode == ParallelMode::DepthOne {
-                ParallelMode::None
-            } else {
-                parallel_mode
-            };
-
-            // Recurse using the remaining matches and updated fragments.
-            recurse_index_search(
-                mol,
-                matches,
-                &state.update(fragments, match_ix, h1.len()),
-                best_index.clone(),
-                bounds,
-                &mut cache.clone(),
-                new_parallel,
-            )
+        // If using depth-one parallelism, all descendant states should be
+        // computed serially.
+        let new_parallel = if parallel_mode == ParallelMode::DepthOne {
+            ParallelMode::None
         } else {
-            (state.index(), 0)
-        }
+            parallel_mode
+        };
+
+        // Recurse using the remaining matches and updated fragments.
+        recurse_index_search(
+            mol,
+            matches,
+            &state.update(fragments, match_ix, h1.len()),
+            best_index.clone(),
+            bounds,
+            &mut cache.clone(),
+            new_parallel,
+        )
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.


### PR DESCRIPTION
This PR drops the `Option<_>` part of `assembly::fragments`'s return type and the corresponding `Some`/`None` check in `assembly::recurse_index_search`.

In #121, we updated match enumeration to use the DAG approach from [Seet et al. (2025)](https://pubs.acs.org/doi/10.1021/acs.jcim.5c01964). Specifically, we implemented `matches::matches_to_remove` which uses the DAG to determine the list of matches that can be removed from a given assembly state. Thus, it is now *impossible* for `assembly::fragments` to ever return `None`, as this would indicate a match cannot be found among an assembly state's fragments.

Benchmarks show this is a performance-neutral change; the rare improvements/regressions seem to be noise.

<details>

<summary>Benchmark b8305c8 (this PR) vs. e7ca3d4 (current main) as a baseline</summary>

```
bench_matches/gdb13_1201/nauty                        
                        time:   [55.221 ms 55.234 ms 55.247 ms]
                        change: [+0.4991% +0.5793% +0.6588%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/gdb13_1201/tree-nauty                        
                        time:   [34.729 ms 34.765 ms 34.811 ms]
                        change: [+2.9248% +3.0520% +3.1796%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/gdb17_200/nauty                        
                        time:   [203.14 ms 203.20 ms 203.27 ms]
                        change: [+1.2093% +1.2660% +1.3229%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/gdb17_200/tree-nauty                        
                        time:   [106.56 ms 106.70 ms 106.82 ms]
                        change: [+2.0659% +2.1926% +2.3128%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/checks/nauty                        
                        time:   [30.141 ms 30.181 ms 30.233 ms]
                        change: [+0.6054% +0.6953% +0.7876%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/checks/tree-nauty                        
                        time:   [13.968 ms 13.983 ms 13.995 ms]
                        change: [-0.5282% -0.4454% -0.3591%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/coconut_55/nauty                        
                        time:   [179.18 ms 179.21 ms 179.24 ms]
                        change: [+0.7371% +0.7962% +0.8556%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/coconut_55/tree-nauty                        
                        time:   [83.964 ms 84.062 ms 84.151 ms]
                        change: [+1.0854% +1.2288% +1.3658%] (p = 0.00 < 0.05)
                        Performance has regressed.

bench_bounds/gdb13_1201/no-bounds                        
                        time:   [60.920 ms 61.287 ms 61.625 ms]
                        change: [-0.8646% +0.0085% +0.8902%] (p = 0.98 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/log                        
                        time:   [59.179 ms 59.745 ms 60.368 ms]
                        change: [-3.6046% -2.5497% -1.2378%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_bounds/gdb13_1201/int                        
                        time:   [57.850 ms 58.321 ms 58.742 ms]
                        change: [-0.0849% +0.8798% +1.7406%] (p = 0.08 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int-vec                        
                        time:   [51.359 ms 51.791 ms 52.279 ms]
                        change: [-6.4040% -5.3993% -4.3477%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_bounds/gdb13_1201/int-matchable                        
                        time:   [57.349 ms 57.749 ms 58.164 ms]
                        change: [-1.2293% -0.1072% +1.0107%] (p = 0.86 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/no-bounds                        
                        time:   [203.63 ms 205.38 ms 207.22 ms]
                        change: [-1.3483% -0.2853% +0.9492%] (p = 0.64 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/log                        
                        time:   [146.55 ms 147.24 ms 148.01 ms]
                        change: [-1.5791% -0.7497% -0.0028%] (p = 0.08 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int                        
                        time:   [49.222 ms 49.394 ms 49.577 ms]
                        change: [-0.6345% +0.0591% +0.7135%] (p = 0.87 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int-vec                        
                        time:   [47.898 ms 48.158 ms 48.406 ms]
                        change: [-0.8997% -0.2249% +0.4297%] (p = 0.51 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int-matchable                        
                        time:   [37.749 ms 37.958 ms 38.174 ms]
                        change: [-2.4704% -1.7673% -0.9470%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_bounds/checks/no-bounds                        
                        time:   [158.64 ms 162.03 ms 165.32 ms]
                        change: [-4.1367% -1.5621% +1.1080%] (p = 0.27 > 0.05)
                        No change in performance detected.
bench_bounds/checks/log time:   [94.643 ms 95.861 ms 97.108 ms]
                        change: [-2.7720% -1.0210% +0.7601%] (p = 0.29 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int time:   [10.769 ms 10.848 ms 10.936 ms]
                        change: [-2.3658% -1.2871% -0.3041%] (p = 0.02 < 0.05)
                        Change within noise threshold.
bench_bounds/checks/int-vec                        
                        time:   [7.6748 ms 7.7125 ms 7.7489 ms]
                        change: [-1.2992% -0.3803% +0.5801%] (p = 0.44 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int-matchable                        
                        time:   [6.1327 ms 6.1569 ms 6.1832 ms]
                        change: [-1.3637% -0.6708% +0.2008%] (p = 0.10 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/no-bounds                        
                        time:   [1.7910 s 1.8408 s 1.8909 s]
                        change: [-9.6726% -5.3646% -1.3278%] (p = 0.03 < 0.05)
                        Performance has improved.
bench_bounds/coconut_55/log                        
                        time:   [1.2862 s 1.3275 s 1.3751 s]
                        change: [-10.168% -4.8163% +0.7437%] (p = 0.12 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int                        
                        time:   [127.90 ms 129.54 ms 131.11 ms]
                        change: [-1.2518% +0.1970% +1.8351%] (p = 0.81 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int-vec                        
                        time:   [113.38 ms 114.79 ms 116.30 ms]
                        change: [-3.0301% -1.6095% -0.1266%] (p = 0.05 < 0.05)
                        Change within noise threshold.
bench_bounds/coconut_55/int-matchable                        
                        time:   [42.591 ms 42.737 ms 42.887 ms]
                        change: [-1.2819% -0.8014% -0.3311%] (p = 0.00 < 0.05)
                        Change within noise threshold.

bench_memoize/gdb13_1201/no-memoize                        
                        time:   [42.556 ms 42.893 ms 43.210 ms]
                        change: [-4.0599% -3.1551% -2.1522%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_memoize/gdb13_1201/nauty-index                        
                        time:   [60.254 ms 60.734 ms 61.188 ms]
                        change: [+1.4022% +2.6080% +3.7734%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_memoize/gdb13_1201/tree-nauty-index                        
                        time:   [56.153 ms 56.693 ms 57.254 ms]
                        change: [-2.4852% -1.1663% +0.2100%] (p = 0.12 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/no-memoize                        
                        time:   [23.467 ms 23.572 ms 23.742 ms]
                        change: [-6.2140% -1.5746% +2.9495%] (p = 0.54 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/nauty-index                        
                        time:   [40.806 ms 41.052 ms 41.288 ms]
                        change: [-0.8827% -0.0600% +0.7286%] (p = 0.88 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/tree-nauty-index                        
                        time:   [38.214 ms 38.411 ms 38.607 ms]
                        change: [-1.6246% -0.9589% -0.2082%] (p = 0.02 < 0.05)
                        Change within noise threshold.
bench_memoize/checks/no-memoize                        
                        time:   [4.1358 ms 4.1508 ms 4.1681 ms]
                        change: [-1.9856% -1.0434% -0.1242%] (p = 0.04 < 0.05)
                        Change within noise threshold.
bench_memoize/checks/nauty-index                        
                        time:   [7.0039 ms 7.0626 ms 7.1412 ms]
                        change: [-1.8450% -0.4827% +0.6898%] (p = 0.49 > 0.05)
                        No change in performance detected.
bench_memoize/checks/tree-nauty-index                        
                        time:   [6.1460 ms 6.1790 ms 6.2105 ms]
                        change: [-2.6432% -1.3694% -0.2210%] (p = 0.03 < 0.05)
                        Change within noise threshold.
bench_memoize/coconut_55/no-memoize                        
                        time:   [33.557 ms 33.704 ms 33.849 ms]
                        change: [-2.1933% -0.9271% +0.3611%] (p = 0.19 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/nauty-index                        
                        time:   [47.577 ms 47.692 ms 47.813 ms]
                        change: [-1.2778% -0.6439% -0.0621%] (p = 0.05 < 0.05)
                        Change within noise threshold.
bench_memoize/coconut_55/tree-nauty-index                        
                        time:   [42.575 ms 42.740 ms 42.894 ms]
                        change: [-1.4038% -0.9432% -0.5088%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

</details>