### PR TITLE
Update all Rust dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,7 +89,7 @@ dependencies = [
  "anyhow",
  "bit-set",
  "bitvec",
- "clap 4.6.1",
+ "clap",
  "criterion",
  "csv",
  "dashmap",
@@ -86,21 +101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bindgen"
@@ -108,46 +112,43 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
 [[package]]
 name = "bit-set"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -163,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cast"
@@ -175,12 +176,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -199,6 +200,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,17 +235,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
-]
-
-[[package]]
-name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap",
- "unicode-width",
 ]
 
 [[package]]
@@ -268,25 +285,24 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
- "atty",
+ "alloca",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
- "itertools 0.10.5",
- "lazy_static",
+ "itertools",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -294,12 +310,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -328,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -364,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -382,15 +404,45 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "glob"
@@ -400,9 +452,14 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "half"
-version = "1.8.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -412,9 +469,18 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -423,31 +489,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -455,15 +503,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -482,25 +521,20 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -523,24 +557,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -597,6 +622,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,12 +646,14 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -680,37 +717,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -718,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -730,13 +762,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -782,14 +813,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -810,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-hash"
@@ -854,16 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -888,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -906,10 +928,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "strsim"
@@ -919,9 +953,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -941,15 +975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "pin-project-lite",
 ]
@@ -973,18 +998,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "utf8parse"
@@ -1004,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1017,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1027,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1040,18 +1053,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1110,6 +1123,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,20 +9,20 @@ repository = "https://github.com/DaymudeLab/assembly-theory"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow = "1.0.95"
-bit-set = "0.8.0"
-clap = { version = "4.5.23", features = ["derive"] }
-csv = "1.3.1"
-petgraph = "0.6.5"
-pyo3 = { version = "0.24.1", features = ["abi3-py310", "extension-module"]}
-rayon = "1.10.0"
-dashmap = "6.1.0"
+anyhow = "1.0.102"
+bit-set = "0.10.0"
+clap = { version = "4.6.1", features = ["derive"] }
+csv = "1.4.0"
+petgraph = "0.8.3"
+pyo3 = { version = "0.29.0", features = ["abi3-py310", "extension-module"]}
+rayon = "1.12.0"
+dashmap = "6.2.1"
 nauty-Traces-sys = "0.11.0"
 bitvec = "1.0.1"
-tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.8.2"
 
 [features]
 default = ["python"]

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -141,7 +141,7 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<
     }
 
     // Drop any singleton fragments, add h1 as a fragment, and return.
-    fragments.retain(|i| i.len() > 1);
+    fragments.retain(|i| i.count() > 1);
     fragments.push(h1.clone());
     fragments
 }
@@ -201,7 +201,7 @@ pub fn recurse_index_search(
         recurse_index_search(
             mol,
             matches,
-            &state.update(fragments, match_ix, h1.len()),
+            &state.update(fragments, match_ix, h1.count()),
             best_index.clone(),
             bounds,
             &mut cache.clone(),

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -138,7 +138,7 @@ pub(crate) fn match_bounds(
 fn log_bound(fragments: &[BitSet]) -> usize {
     let mut size = 0;
     for f in fragments {
-        size += f.len();
+        size += f.count();
     }
 
     size - (size as f32).log2().ceil() as usize
@@ -150,7 +150,7 @@ fn int_bound(fragments: &[BitSet], m: usize) -> usize {
     let mut frag_sizes: Vec<usize> = Vec::new();
 
     for f in fragments {
-        frag_sizes.push(f.len());
+        frag_sizes.push(f.count());
     }
 
     let size_sum: usize = frag_sizes.iter().sum();
@@ -211,7 +211,7 @@ fn vec_simple_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> usize {
     // Calculate z (number of unique edges)
     let mut s = 0;
     for f in fragments {
-        s += f.len();
+        s += f.count();
     }
 
     let mut union_set = BitSet::new();
@@ -231,7 +231,7 @@ fn vec_small_frags_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> usiz
 
     // Find and remove fragments of size 2
     for (i, frag) in fragments.iter().enumerate() {
-        if frag.len() == 2 {
+        if frag.count() == 2 {
             indices_to_remove.push(i);
         }
     }
@@ -257,10 +257,10 @@ fn vec_small_frags_bound(fragments: &[BitSet], m: usize, mol: &Molecule) -> usiz
     let mut s = 0;
     let mut sl = 0;
     for f in fragments {
-        s += f.len();
+        s += f.count();
     }
     for f in large_fragments {
-        sl += f.len();
+        sl += f.count();
     }
 
     // Find number of unique size two fragments
@@ -286,8 +286,8 @@ fn usable_edges_bound(matchable_edge_masks: &[Vec<BitSet>], removal_size: usize)
     let mut bound = 0;
 
     for (frag_ix, frag) in matchable_edge_masks[removal_size - 2].iter().enumerate() {
-        let total_removable_edges = matchable_edge_masks[0][frag_ix].len();
-        let removable_edges = frag.len();
+        let total_removable_edges = matchable_edge_masks[0][frag_ix].count();
+        let removable_edges = frag.count();
         let leftover_edges =
             (total_removable_edges - removable_edges) + (removable_edges % removal_size);
         bound += total_removable_edges

--- a/src/canonize.rs
+++ b/src/canonize.rs
@@ -72,7 +72,7 @@ type CGraph = Graph<AtomOrBond, (), Undirected, Index>;
 
 /// Convert the specified `subgraph` to the format expected by Nauty.
 fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
-    let mut h = CGraph::with_capacity(subgraph.len(), 2 * subgraph.len());
+    let mut h = CGraph::with_capacity(subgraph.count(), 2 * subgraph.count());
     let mut vtx_map = HashMap::<NodeIndex, NodeIndex>::new();
     for e in subgraph {
         let eix = EdgeIndex::new(e);
@@ -98,7 +98,7 @@ fn subgraph_to_cgraph(mol: &Molecule, subgraph: &BitSet) -> CGraph {
 
 /// Returns `True` iff the *connected* `subgraph` induces a tree.
 fn is_tree(mol: &Molecule, subgraph: &BitSet) -> bool {
-    node_count_under_edge_mask(mol.graph(), subgraph) == subgraph.len() + 1
+    node_count_under_edge_mask(mol.graph(), subgraph) == subgraph.count() + 1
 }
 
 /// Wrap a bytevec with 0..vec..255.
@@ -161,10 +161,10 @@ fn tree_canonize(mol: &Molecule, subgraph: &BitSet) -> Vec<u8> {
     }
 
     // Leaf pruning proceeds until the tree is an isolated edge or node.
-    while unlabeled_vertices.len() > 2 {
+    while unlabeled_vertices.count() > 2 {
         let leaves = unlabeled_vertices
             .iter()
-            .filter(|&i| adjacencies[i].len() == 1)
+            .filter(|&i| adjacencies[i].count() == 1)
             .collect::<Vec<_>>();
 
         for leaf in leaves {
@@ -182,13 +182,13 @@ fn tree_canonize(mol: &Molecule, subgraph: &BitSet) -> Vec<u8> {
             partial_canonical_sets[parent].push(canonical_label);
 
             // Proceed as though the pruned leaf no longer exists.
-            adjacencies[leaf].clear();
+            adjacencies[leaf].make_empty();
             adjacencies[parent].remove(leaf);
             unlabeled_vertices.remove(leaf);
         }
     }
 
-    if unlabeled_vertices.len() == 2 {
+    if unlabeled_vertices.count() == 2 {
         // Case 1: Tree collapses into isolated edge. Obtain node labels,
         // lexicographically sort, and then glue together into canonical label
         // alongside edge weight.

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -329,7 +329,7 @@ impl Matches {
                 matchable_edge_masks[0]
                     .iter()
                     .flat_map(|frag| connected_components_under_edges(mol.graph(), frag))
-                    .filter(|frag| frag.len() >= 2)
+                    .filter(|frag| frag.count() >= 2)
                     .collect::<Vec<BitSet>>()
             } else {
                 vec![]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,7 +77,7 @@ where
         node_set.insert(src.index());
         node_set.insert(dst.index());
     }
-    node_set.len()
+    node_set.count()
 }
 
 pub fn node_induced_subgraph<N, E, Ty, Ix>(
@@ -141,11 +141,11 @@ where
     let mut components = Vec::new();
     while let Some(c) = remainder.iter().next() {
         let mut queue = BitSet::new();
-        queue.reserve_len(s.len());
+        queue.reserve_len(s.count());
         queue.insert(c);
 
         let mut visited = BitSet::new();
-        visited.reserve_len(s.len());
+        visited.reserve_len(s.count());
 
         while let Some(e) = queue.iter().next() {
             queue.remove(e);


### PR DESCRIPTION
I realize it's typically not best practice to update all dependencies in one go, but it's been a while since we checked in on them and there's a handful of feature and security updates we'd benefit from. I have read each explicit dependency's changelog (if one exists), ensured there are no breaking changes, fixed all deprecations, and ran benchmarks which show this PR is performance-netural.

<details>

<summary>Benchmark 7bd28f7 (this PR) vs. 4989aac (current main) as a baseline</summary>

```
bench_matches/gdb13_1201/nauty
                        time:   [55.423 ms 55.512 ms 55.590 ms]
                        change: [+0.3919% +0.5813% +0.7099%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/gdb13_1201/tree-nauty
                        time:   [34.646 ms 34.728 ms 34.785 ms]
                        change: [−2.9632% −2.5590% −2.1703%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_matches/gdb17_200/nauty
                        time:   [202.57 ms 202.67 ms 202.77 ms]
                        change: [+1.1714% +1.2584% +1.3487%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/gdb17_200/tree-nauty
                        time:   [106.83 ms 106.89 ms 106.94 ms]
                        change: [+0.5232% +0.6041% +0.6890%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/checks/nauty
                        time:   [30.111 ms 30.118 ms 30.125 ms]
                        change: [+1.1477% +1.1907% +1.2317%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/checks/tree-nauty
                        time:   [14.170 ms 14.182 ms 14.192 ms]
                        change: [−1.0248% −0.9564% −0.8845%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_matches/coconut_55/nauty
                        time:   [179.22 ms 179.29 ms 179.36 ms]
                        change: [+2.0739% +2.1573% +2.2341%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_matches/coconut_55/tree-nauty
                        time:   [84.189 ms 84.262 ms 84.331 ms]
                        change: [+0.1978% +0.5263% +0.8783%] (p = 0.00 < 0.05)
                        Change within noise threshold.

bench_bounds/gdb13_1201/no-bounds
                        time:   [60.084 ms 60.527 ms 60.958 ms]
                        change: [−2.3365% −1.3951% −0.4891%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_bounds/gdb13_1201/log
                        time:   [59.610 ms 60.196 ms 60.805 ms]
                        change: [−1.6710% −0.5399% +0.6784%] (p = 0.39 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int
                        time:   [55.817 ms 56.368 ms 56.946 ms]
                        change: [−3.6602% −2.5518% −1.4043%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_bounds/gdb13_1201/int-vec
                        time:   [53.949 ms 54.375 ms 54.820 ms]
                        change: [−0.2752% +0.7693% +1.8962%] (p = 0.19 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int-matchable
                        time:   [54.874 ms 55.304 ms 55.740 ms]
                        change: [−5.0440% −3.9436% −2.7048%] (p = 0.00 < 0.05)
                        Performance has improved.
bench_bounds/gdb17_200/no-bounds
                        time:   [205.90 ms 207.65 ms 209.35 ms]
                        change: [−0.3314% +0.8868% +2.1670%] (p = 0.17 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/log
                        time:   [146.73 ms 147.43 ms 148.18 ms]
                        change: [−0.3318% +0.3433% +1.0174%] (p = 0.35 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int
                        time:   [49.398 ms 49.629 ms 49.851 ms]
                        change: [+0.3888% +0.9719% +1.6147%] (p = 0.01 < 0.05)
                        Change within noise threshold.
bench_bounds/gdb17_200/int-vec
                        time:   [47.887 ms 48.157 ms 48.417 ms]
                        change: [−0.6920% +0.0465% +0.7971%] (p = 0.91 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int-matchable
                        time:   [38.255 ms 38.487 ms 38.732 ms]
                        change: [+0.1704% +1.0434% +1.9292%] (p = 0.03 < 0.05)
                        Change within noise threshold.
bench_bounds/checks/no-bounds
                        time:   [157.97 ms 161.12 ms 164.29 ms]
                        change: [−2.6697% +0.1277% +3.1474%] (p = 0.93 > 0.05)
                        No change in performance detected.
bench_bounds/checks/log time:   [94.205 ms 95.374 ms 96.514 ms]
                        change: [−2.4183% −0.8807% +0.6374%] (p = 0.30 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int time:   [10.813 ms 10.867 ms 10.927 ms]
                        change: [−1.1307% −0.1760% +0.6794%] (p = 0.72 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int-vec
                        time:   [7.6954 ms 7.7284 ms 7.7615 ms]
                        change: [−1.4169% −0.2715% +0.8692%] (p = 0.65 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int-matchable
                        time:   [6.1734 ms 6.2036 ms 6.2417 ms]
                        change: [+0.4163% +1.1515% +1.8559%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_bounds/coconut_55/no-bounds
                        time:   [1.8255 s 1.8730 s 1.9170 s]
                        change: [−2.7240% +0.6994% +4.4198%] (p = 0.71 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/log
                        time:   [1.3284 s 1.3528 s 1.3788 s]
                        change: [+0.0588% +2.7786% +5.8788%] (p = 0.07 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int
                        time:   [127.40 ms 128.67 ms 129.91 ms]
                        change: [−2.4316% −0.9979% +0.5333%] (p = 0.20 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int-vec
                        time:   [112.51 ms 113.80 ms 115.04 ms]
                        change: [−2.6136% −1.1578% +0.3345%] (p = 0.14 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int-matchable
                        time:   [42.930 ms 43.121 ms 43.330 ms]
                        change: [−0.6034% −0.0089% +0.6358%] (p = 0.98 > 0.05)
                        No change in performance detected.

bench_memoize/gdb13_1201/no-memoize
                        time:   [43.860 ms 44.177 ms 44.476 ms]
                        change: [−0.5233% +0.2064% +1.0248%] (p = 0.64 > 0.05)
                        No change in performance detected.
bench_memoize/gdb13_1201/nauty-index
                        time:   [60.122 ms 60.671 ms 61.183 ms]
                        change: [−1.0227% +0.3269% +1.6008%] (p = 0.63 > 0.05)
                        No change in performance detected.
bench_memoize/gdb13_1201/tree-nauty-index
                        time:   [57.703 ms 58.101 ms 58.499 ms]
                        change: [−0.2185% +0.8118% +1.8349%] (p = 0.14 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/no-memoize
                        time:   [23.917 ms 23.989 ms 24.107 ms]
                        change: [−2.7861% +1.0154% +5.3886%] (p = 0.64 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/nauty-index
                        time:   [40.837 ms 41.016 ms 41.184 ms]
                        change: [−0.5814% +0.1324% +0.8347%] (p = 0.72 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/tree-nauty-index
                        time:   [38.274 ms 38.502 ms 38.745 ms]
                        change: [+0.0500% +0.8521% +1.7436%] (p = 0.07 > 0.05)
                        No change in performance detected.
bench_memoize/checks/no-memoize
                        time:   [4.1886 ms 4.2295 ms 4.2677 ms]
                        change: [−0.0703% +0.9190% +1.9527%] (p = 0.07 > 0.05)
                        No change in performance detected.
bench_memoize/checks/nauty-index
                        time:   [7.0216 ms 7.0503 ms 7.0803 ms]
                        change: [−0.3499% +0.2591% +0.9501%] (p = 0.45 > 0.05)
                        No change in performance detected.
bench_memoize/checks/tree-nauty-index
                        time:   [6.1511 ms 6.2006 ms 6.2615 ms]
                        change: [−0.0050% +1.3439% +2.7620%] (p = 0.08 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/no-memoize
                        time:   [33.539 ms 33.655 ms 33.790 ms]
                        change: [−2.8986% −1.2576% +0.2728%] (p = 0.15 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/nauty-index
                        time:   [47.548 ms 47.841 ms 48.184 ms]
                        change: [−0.1447% +0.6206% +1.4971%] (p = 0.14 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/tree-nauty-index
                        time:   [42.801 ms 42.946 ms 43.114 ms]
                        change: [−0.6143% −0.1038% +0.4358%] (p = 0.70 > 0.05)
                        No change in performance detected.
```

</details>

Fixes:
- https://github.com/DaymudeLab/assembly-theory/security/dependabot/1
- https://github.com/DaymudeLab/assembly-theory/security/dependabot/24
- https://github.com/DaymudeLab/assembly-theory/security/dependabot/25