### PR TITLE
Extract minimum assembly pathways as directed acyclic graphs of fragments

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -126,6 +126,7 @@ pub fn bench_bounds(c: &mut Criterion) {
                                     bounds,
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    false,
                                 );
                                 total_time += start.elapsed();
                             }
@@ -190,6 +191,7 @@ pub fn bench_memoize(c: &mut Criterion) {
                                     &[Bound::Int, Bound::MatchableEdges],
                                     &mut cache,
                                     ParallelMode::DepthOne,
+                                    false,
                                 );
                                 total_time += start.elapsed();
                             }
@@ -204,9 +206,59 @@ pub fn bench_memoize(c: &mut Criterion) {
     bench_group.finish();
 }
 
+/// Benchmark the search step of [`index_search`] when assembly pathway reconstruction is enabled,
+/// recursively collecting all minimum match removal orders.
+///
+/// This benchmark precomputes matches information using the fastest options and times only the
+/// search step with default search options and removal order collection enabled.
+pub fn bench_removal_orders(c: &mut Criterion) {
+    let mut bench_group = c.benchmark_group("bench_removal_orders");
+
+    // Define datasets.
+    let datasets = ["gdb13_1201", "gdb17_200", "checks", "coconut_55"];
+
+    // Run the benchmark for each dataset and bound list.
+    for dataset in &datasets {
+        let mol_list = load_dataset_molecules(dataset);
+        bench_group.bench_with_input(*dataset, &(), |b, ()| {
+            b.iter_custom(|iters| {
+                let mut total_time = Duration::new(0, 0);
+                for mol in &mol_list {
+                    // Precompute the molecule's matches and setup.
+                    let matches = Matches::new(mol, CanonizeMode::TreeNauty);
+                    let state = State::new(mol);
+                    let edge_count = mol.graph().edge_count();
+
+                    // Benchmark the search phase.
+                    for _ in 0..iters {
+                        let mut cache =
+                            Cache::new(MemoizeMode::CanonIndex, CanonizeMode::TreeNauty);
+                        let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
+                        let start = Instant::now();
+                        recurse_index_search(
+                            mol,
+                            &matches,
+                            &state,
+                            best_index,
+                            &[Bound::Int, Bound::MatchableEdges],
+                            &mut cache,
+                            ParallelMode::DepthOne,
+                            true,
+                        );
+                        total_time += start.elapsed();
+                    }
+                }
+                total_time
+            });
+        });
+    }
+
+    bench_group.finish();
+}
+
 criterion_group! {
     name = benchmark;
     config = Criterion::default().sample_size(20);
-    targets = bench_matches, bench_bounds, bench_memoize
+    targets = bench_matches, bench_bounds, bench_memoize, bench_removal_orders
 }
 criterion_main!(benchmark);

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -126,7 +126,7 @@ pub fn bench_bounds(c: &mut Criterion) {
                                     bounds,
                                     &mut cache,
                                     ParallelMode::DepthOne,
-                                    false,
+                                    None,
                                 );
                                 total_time += start.elapsed();
                             }
@@ -191,7 +191,7 @@ pub fn bench_memoize(c: &mut Criterion) {
                                     &[Bound::Int, Bound::MatchableEdges],
                                     &mut cache,
                                     ParallelMode::DepthOne,
-                                    false,
+                                    None,
                                 );
                                 total_time += start.elapsed();
                             }
@@ -216,41 +216,48 @@ pub fn bench_removal_orders(c: &mut Criterion) {
 
     // Define datasets.
     let datasets = ["gdb13_1201", "gdb17_200", "checks", "coconut_55"];
+    let nums_orders = [(None, "none"), (Some(1), "one"), (Some(0), "all")];
 
     // Run the benchmark for each dataset and bound list.
     for dataset in &datasets {
         let mol_list = load_dataset_molecules(dataset);
-        bench_group.bench_with_input(*dataset, &(), |b, ()| {
-            b.iter_custom(|iters| {
-                let mut total_time = Duration::new(0, 0);
-                for mol in &mol_list {
-                    // Precompute the molecule's matches and setup.
-                    let matches = Matches::new(mol, CanonizeMode::TreeNauty);
-                    let state = State::new(mol);
-                    let edge_count = mol.graph().edge_count();
+        for (num_orders, name) in &nums_orders {
+            bench_group.bench_with_input(
+                BenchmarkId::new(*dataset, &name),
+                &num_orders,
+                |b, &num_orders| {
+                    b.iter_custom(|iters| {
+                        let mut total_time = Duration::new(0, 0);
+                        for mol in &mol_list {
+                            // Precompute the molecule's matches and setup.
+                            let matches = Matches::new(mol, CanonizeMode::TreeNauty);
+                            let state = State::new(mol);
+                            let edge_count = mol.graph().edge_count();
 
-                    // Benchmark the search phase.
-                    for _ in 0..iters {
-                        let mut cache =
-                            Cache::new(MemoizeMode::CanonIndex, CanonizeMode::TreeNauty);
-                        let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
-                        let start = Instant::now();
-                        recurse_index_search(
-                            mol,
-                            &matches,
-                            &state,
-                            best_index,
-                            &[Bound::Int, Bound::MatchableEdges],
-                            &mut cache,
-                            ParallelMode::DepthOne,
-                            true,
-                        );
-                        total_time += start.elapsed();
-                    }
-                }
-                total_time
-            });
-        });
+                            // Benchmark the search phase.
+                            for _ in 0..iters {
+                                let mut cache =
+                                    Cache::new(MemoizeMode::CanonIndex, CanonizeMode::TreeNauty);
+                                let best_index = Arc::new(AtomicUsize::from(edge_count - 1));
+                                let start = Instant::now();
+                                recurse_index_search(
+                                    mol,
+                                    &matches,
+                                    &state,
+                                    best_index,
+                                    &[Bound::Int, Bound::MatchableEdges],
+                                    &mut cache,
+                                    ParallelMode::DepthOne,
+                                    *num_orders,
+                                );
+                                total_time += start.elapsed();
+                            }
+                        }
+                        total_time
+                    });
+                },
+            );
+        }
     }
 
     bench_group.finish();

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -150,7 +150,7 @@ pub fn bench_bounds(c: &mut Criterion) {
 pub fn bench_memoize(c: &mut Criterion) {
     let mut bench_group = c.benchmark_group("bench_memoize");
 
-    // Define datasets and bound lists.
+    // Define datasets and memoization modes.
     let datasets = ["gdb13_1201", "gdb17_200", "checks", "coconut_55"];
     let memoize_modes = [
         (MemoizeMode::None, CanonizeMode::Nauty, "no-memoize"),
@@ -162,7 +162,7 @@ pub fn bench_memoize(c: &mut Criterion) {
         ),
     ];
 
-    // Run the benchmark for each dataset and bound list.
+    // Run the benchmark for each dataset and memoization mode.
     for dataset in &datasets {
         let mol_list = load_dataset_molecules(dataset);
         for (memoize_mode, canonize_mode, name) in &memoize_modes {
@@ -206,11 +206,12 @@ pub fn bench_memoize(c: &mut Criterion) {
     bench_group.finish();
 }
 
-/// Benchmark the search step of [`index_search`] when assembly pathway reconstruction is enabled,
-/// recursively collecting all minimum match removal orders.
+/// Benchmark the search step of [`index_search`] when recursively collecting different numbers of
+/// match removal orders.
 ///
 /// This benchmark precomputes matches information using the fastest options and times only the
-/// search step with default search options and removal order collection enabled.
+/// search step when collecting no, one, and all match removal orders. This benchmark otherwise
+/// usese the default search options.
 pub fn bench_removal_orders(c: &mut Criterion) {
     let mut bench_group = c.benchmark_group("bench_removal_orders");
 
@@ -218,7 +219,7 @@ pub fn bench_removal_orders(c: &mut Criterion) {
     let datasets = ["gdb13_1201", "gdb17_200", "checks", "coconut_55"];
     let nums_orders = [(None, "none"), (Some(1), "one"), (Some(0), "all")];
 
-    // Run the benchmark for each dataset and bound list.
+    // Run the benchmark for each dataset and number of match removal orders to collect.
     for dataset in &datasets {
         let mol_list = load_dataset_molecules(dataset);
         for (num_orders, name) in &nums_orders {

--- a/python/tests/test_assembly_theory.py
+++ b/python/tests/test_assembly_theory.py
@@ -64,7 +64,7 @@ def test_index_search():
     with open(osp.join("data", "checks", "anthracene.mol")) as f:
         mol_block = f.read()
 
-    (index, num_matches, states_searched) = at.index_search(
+    (index, num_matches, states_searched, pathways) = at.index_search(
         mol_block,
         timeout=None,
         canonize_str="tree-nauty",
@@ -72,16 +72,46 @@ def test_index_search():
         memoize_str="none",
         kernel_str="none",
         bound_strs=["int", "matchable-edges"],
+        max_pathways=1,
     )
 
-    assert (index, num_matches, states_searched) == (6, 466, 491)
+    pathway_str = """digraph {
+    0 [ label = "{14}" ]
+    1 [ label = "{15}" ]
+    2 [ label = "{14, 15}" ]
+    3 [ label = "{7, 14, 15}" ]
+    4 [ label = "{6, 7, 14, 15}" ]
+    5 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+    6 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+    7 [ label = "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}" ]
+    0 -> 2 [ label = "{14}" ]
+    1 -> 2 [ label = "{15}" ]
+    0 -> 3 [ label = "{7}" ]
+    2 -> 3 [ label = "{14, 15}" ]
+    1 -> 4 [ label = "{6}" ]
+    3 -> 4 [ label = "{7, 14, 15}" ]
+    4 -> 5 [ label = "{6, 7, 14, 15}" ]
+    3 -> 5 [ label = "{3, 4, 5}" ]
+    2 -> 6 [ label = "{2, 13}" ]
+    5 -> 6 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+    6 -> 7 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+    5 -> 7 [ label = "{0, 1, 8, 9, 10, 11, 12}" ]
+}
+"""
+
+    assert (index, num_matches, states_searched, pathways) == (
+        6,
+        466,
+        491,
+        [pathway_str],
+    )
 
 
 def test_index_search_timeout():
     with open(osp.join("data", "checks", "anthracene.mol")) as f:
         mol_block = f.read()
 
-    (_, _, states_searched) = at.index_search(
+    (_, _, states_searched, pathways) = at.index_search(
         mol_block,
         timeout=1,  # Limit search to 1 ms, which should time out.
         canonize_str="tree-nauty",
@@ -89,9 +119,10 @@ def test_index_search_timeout():
         memoize_str="none",
         kernel_str="none",
         bound_strs=[],
+        max_pathways=0,
     )
 
-    assert states_searched is None
+    assert (states_searched is None) and (pathways == [])
 
 
 def test_index_search_bad_molblock():

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -283,6 +283,10 @@ pub fn recurse_index_search(
 /// the order they appear in the `bounds` slice. It is generally better to
 /// provide bounds that are quick to compute first.
 ///
+/// If `max_pathways` is `None`, skip minimum assembly pathway reconstruction.
+/// Otherwise, reconstruct all such pathways from the completed search results
+/// if `max_pathways == 0` or at most `max_pathways` such pathways otherwise.
+///
 /// The results returned are:
 /// - The molecule's `u32` assembly index (or an upper bound if timed out).
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
@@ -317,7 +321,9 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     None,
 /// );
+/// assert_eq!(slow_index, 6);
 ///
 /// // Compute the molecule's assembly index with parallelism, memoization, and
 /// // some bounds.
@@ -329,7 +335,9 @@ pub fn recurse_index_search(
 ///     MemoizeMode::CanonIndex,
 ///     KernelMode::None,
 ///     &[Bound::Log, Bound::Int],
+///     None,
 /// );
+/// assert_eq!(fast_index, 6);
 ///
 /// // Limit search to 1 ms, which should time out.
 /// let (index_bound, _, states_searched) = index_search(
@@ -340,10 +348,8 @@ pub fn recurse_index_search(
 ///     MemoizeMode::None,
 ///     KernelMode::None,
 ///     &[],
+///     None,
 /// );
-///
-/// assert_eq!(slow_index, 6);
-/// assert_eq!(fast_index, 6);
 /// assert!(index_bound >= fast_index && states_searched == None);
 /// # Ok(())
 /// # }
@@ -356,6 +362,7 @@ pub fn index_search(
     memoize_mode: MemoizeMode,
     kernel_mode: KernelMode,
     bounds: &[Bound],
+    max_pathways: Option<usize>,
 ) -> (u32, u32, Option<usize>) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
@@ -368,19 +375,19 @@ pub fn index_search(
 
     // Enumerate matches (i.e., pairs of edge-disjoint isomorphic fragments).
     let matches = Matches::new(mol, canonize_mode);
+    let num_matches = matches.len();
 
     // Use an `Arc` to track the best assembly index across parallel threads.
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
 
     // Search for the shortest assembly pathway recursively.
-    if let Some(timeout) = timeout {
+    let (index, states_searched, _) = if let Some(timeout) = timeout {
         // If a timeout is provided, we will search within an asynchronous task
         // that can be interrupted after the specified duration (see below). To
         // avoid subsequent scope issues, make copies of various variables.
         let best_index_copy = best_index.clone();
         let mol = mol.clone();
         let bounds = bounds.to_vec();
-        let num_matches = matches.len();
 
         // Search within a dedicated asynchronous runtime.
         let rt = Runtime::new().unwrap();
@@ -395,7 +402,7 @@ pub fn index_search(
                     &bounds,
                     &mut cache,
                     parallel_mode,
-                    true,
+                    max_pathways.is_some(),
                 ));
             });
             tktimeout(Duration::from_millis(timeout), recv).await
@@ -404,12 +411,13 @@ pub fn index_search(
         // If the search completes before the timeout, return the true assembly
         // index. Otherwise, return the best upper bound on the assembly index
         // found before timing out.
-        let (index, states_searched) = match result {
-            Ok(Ok((index, states_searched, removal_orders))) => (index, Some(states_searched)),
-            Err(_) => (best_index.load(Relaxed), None),
+        match result {
+            Ok(Ok((index, states_searched, removal_orders))) => {
+                (index, Some(states_searched), removal_orders)
+            }
+            Err(_) => (best_index.load(Relaxed), None, None),
             _ => panic!("An unexpected error occurred in async index_search"),
-        };
-        (index as u32, num_matches as u32, states_searched)
+        }
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
         let (index, states_searched, removal_orders) = recurse_index_search(
@@ -420,16 +428,18 @@ pub fn index_search(
             bounds,
             &mut cache,
             parallel_mode,
-            true,
+            max_pathways.is_some(),
         );
-        (index as u32, matches.len() as u32, Some(states_searched))
-    }
+        (index, Some(states_searched), removal_orders)
+    };
+
+    (index as u32, num_matches as u32, states_searched)
 }
 
 /// Compute a molecule's assembly index using an efficient default strategy.
 ///
-/// To customize assembly index calculation beyond the default strategy, see
-/// [`index_search`].
+/// To customize assembly index calculation beyond the default strategy and/or
+/// reconstruct minimum assembly pathways, see [`index_search`].
 ///
 /// # Example
 /// ```
@@ -457,6 +467,7 @@ pub fn index(mol: &Molecule) -> u32 {
         MemoizeMode::CanonIndex,
         KernelMode::None,
         &[Bound::Int, Bound::MatchableEdges],
+        None, // Disable pathway reconstruction.
     )
     .0
 }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -296,14 +296,15 @@ pub fn recurse_index_search(
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
-/// - A vector of of minimum assembly [`Pathway`]s that is nonempty if and only
-///   if search did not time out and `max_pathways` is not `None`.
+/// - A vector of the molecule's minimum assembly [`Pathway`]s that is nonempty
+///   if and only if search did not time out and `max_pathways` is not `None`.
 ///
-/// # Customizing Assembly Index Search Options
+/// # Examples
+///
+/// ## Customizing Assembly Index Search Options
 ///
 /// The two examples below show different customizations of the assembly index
-/// search options, enabling/disabling parallelism and memoization and choosing
-/// different combinations of bounds.
+/// search options, enabling/disabling parallelism, memoization, and bounding.
 /// ```
 /// # use std::{fs, path::PathBuf};
 /// use assembly_theory::{
@@ -321,9 +322,9 @@ pub fn recurse_index_search(
 /// let molfile = fs::read_to_string(path)?;
 /// let anthracene = parse_molfile_str(&molfile).expect("Parsing failure.");
 ///
-/// // Compute the molecule's assembly index without parallelism, memoization,
-/// // kernelization, or bounds.
-/// let (slow_index, _, _, _) = index_search(
+/// // Calculate the molecule's assembly index without any search optimizations
+/// // like parallelism, memoization, kernelization, or bounding.
+/// let (slow_index, num_matches, states_searched, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -334,10 +335,11 @@ pub fn recurse_index_search(
 ///     None,
 /// );
 /// assert_eq!(slow_index, 6);
+/// assert_eq!(num_matches, 466);
+/// assert_eq!(states_searched, Some(133814));
 ///
-/// // Compute the molecule's assembly index with parallelism, memoization, and
-/// // some bounds.
-/// let (fast_index, _, _, _) = index_search(
+/// // Repeat the calculation with parallelism, memoization, and some bounds.
+/// let (fast_index, num_matches, states_searched, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -348,11 +350,13 @@ pub fn recurse_index_search(
 ///     None,
 /// );
 /// assert_eq!(fast_index, 6);
+/// assert_eq!(num_matches, 466);
+/// // Note: states_searched is now nondeterministic because of parallelism.
 /// # Ok(())
 /// # }
 /// ```
 ///
-/// # Setting a Timeout for Long Calculations
+/// ## Setting a Timeout for Long Calculations
 ///
 /// Assembly index calculation can be slow on large molecules, even with search
 /// optimizations enabled. If `timeout` is set, two outcomes are possible:
@@ -380,29 +384,29 @@ pub fn recurse_index_search(
 /// // even with some search optimizations disabled.
 /// let (true_index, num_matches, states_searched, pathways) = index_search(
 ///     &anthracene,
-///     Some(10000), // Set a 10 s timeout.
+///     Some(10000),               // Set a 10 s timeout.
 ///     CanonizeMode::TreeNauty,
-///     ParallelMode::None,
-///     MemoizeMode::None,
-///     KernelMode::None,
-///     &[Bound::Int, Bound::MatchableEdges],
-///     Some(1),
+///     ParallelMode::None,        // Disable parallelism.
+///     MemoizeMode::None,         // Disable memoization.
+///     KernelMode::None,          // Disable kernelization.
+///     &[Bound::Log, Bound::Int], // Enable some bounds.
+///     Some(1),                   // Reconstuct one pathway.
 /// );
 /// assert_eq!(true_index, 6);
 /// assert_eq!(num_matches, 466);
-/// assert_eq!(states_searched, Some(491));
+/// assert_eq!(states_searched, Some(2454));
 /// assert_eq!(pathways.len(), 1);
 ///
 /// // Limit search to 1 ms, which will time out without more optimizations.
 /// let (index_bound, num_matches, states_searched, pathways) = index_search(
 ///     &anthracene,
-///     Some(1), // Set a 1 ms timeout.
+///     Some(1),                   // Set a 1 ms timeout.
 ///     CanonizeMode::TreeNauty,
-///     ParallelMode::None,
-///     MemoizeMode::None,
-///     KernelMode::None,
-///     &[Bound::Int, Bound::MatchableEdges],
-///     Some(1),
+///     ParallelMode::None,        // Disable parallelism.
+///     MemoizeMode::None,         // Disable memoization.
+///     KernelMode::None,          // Disable kernelization.
+///     &[Bound::Log, Bound::Int], // Enable some bounds.
+///     Some(1),                   // Reconstuct one pathway.
 /// );
 /// assert!(index_bound >= true_index); // Index is an upper bound on timeout.
 /// assert_eq!(num_matches, 466);       // The number of matches is unaffected.
@@ -412,13 +416,13 @@ pub fn recurse_index_search(
 /// # }
 /// ```
 ///
-/// # Reconstructing Minimum Assembly Pathways
+/// ## Reconstructing Minimum Assembly Pathways
 ///
 /// An assembly [`Pathway`] records the fragment join operations producing the
 /// target molecule. Set `max_pathways` to `Some(0)` to reconstruct all minimum
-/// assembly pathways discovered by the search process, `Some(n)` for the first
-/// `n` such pathways, or `None` to disable pathway reconstruction. See
-/// [`Pathway::dag`] for details on the pathway data structure.
+/// assembly pathways discovered by the search process, `Some(n)` for at most
+/// the first `n` such pathways, or `None` to disable pathway reconstruction.
+/// See [`Pathway::dag`] for details on the pathway data structure.
 ///
 /// Note that the definition of `Some(0)`'s behavior is very carefully worded:
 /// it finds all minimum assembly pathways *discovered by the search process*.

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -441,7 +441,7 @@ pub fn index_search(
     if let Some(max_pathways) = max_pathways {
         if let Some(mut removal_orders) = removal_orders {
             for (ix, removal_order) in removal_orders.drain().enumerate() {
-                if ix >= max_pathways {
+                if max_pathways > 0 && ix >= max_pathways {
                     break;
                 } else {
                     pathways.push(Pathway::new(mol, &matches, &removal_order));

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -172,6 +172,7 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<
 /// - `Option<HashSet<Vec<usize>>>`: A set of assembly states' match removal
 ///   orders that attain the updated assembly index upper bound, or `None` if
 ///   `collect_removal_orders == false`.
+#[allow(clippy::too_many_arguments)]
 pub fn recurse_index_search(
     mol: &Molecule,
     matches: &Matches,
@@ -230,6 +231,7 @@ pub fn recurse_index_search(
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.
+    #[allow(clippy::type_complexity)]
     let results: Vec<(usize, usize, Option<HashSet<Vec<usize>>>)> =
         if parallel_mode == ParallelMode::None {
             matches_to_remove
@@ -485,6 +487,7 @@ pub fn recurse_index_search(
 /// # Ok(())
 /// # }
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn index_search(
     mol: &Molecule,
     timeout: Option<u64>,
@@ -579,7 +582,7 @@ pub fn index_search(
                 if max_pathways > 0 && ix >= max_pathways {
                     break;
                 } else {
-                    pathways.push(Pathway::new(mol, &matches, &removal_order));
+                    pathways.push(Pathway::new(mol, &matches, removal_order));
                 }
             }
         }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -39,6 +39,7 @@ use crate::{
     matches::Matches,
     memoize::{Cache, MemoizeMode},
     molecule::Molecule,
+    pathway::Pathway,
     state::State,
     utils::connected_components_under_edges,
 };
@@ -292,6 +293,7 @@ pub fn recurse_index_search(
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
+/// - A vector of of minimum assembly [`Pathway`]s.
 ///
 /// # Example
 /// ```
@@ -313,7 +315,7 @@ pub fn recurse_index_search(
 ///
 /// // Compute the molecule's assembly index without parallelism, memoization,
 /// // kernelization, or bounds.
-/// let (slow_index, _, _) = index_search(
+/// let (slow_index, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -327,7 +329,7 @@ pub fn recurse_index_search(
 ///
 /// // Compute the molecule's assembly index with parallelism, memoization, and
 /// // some bounds.
-/// let (fast_index, _, _) = index_search(
+/// let (fast_index, _, _, _) = index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
@@ -340,7 +342,7 @@ pub fn recurse_index_search(
 /// assert_eq!(fast_index, 6);
 ///
 /// // Limit search to 1 ms, which should time out.
-/// let (index_bound, _, states_searched) = index_search(
+/// let (index_bound, _, states_searched, _) = index_search(
 ///     &anthracene,
 ///     Some(1),
 ///     CanonizeMode::TreeNauty,
@@ -363,7 +365,7 @@ pub fn index_search(
     kernel_mode: KernelMode,
     bounds: &[Bound],
     max_pathways: Option<usize>,
-) -> (u32, u32, Option<usize>) {
+) -> (u32, u32, Option<usize>, Vec<Pathway>) {
     // Catch not-yet-implemented modes.
     if kernel_mode != KernelMode::None {
         panic!("The chosen --kernel mode is not implemented yet!")
@@ -380,7 +382,7 @@ pub fn index_search(
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
 
     // Search for the shortest assembly pathway recursively.
-    let (index, states_searched, _) = if let Some(timeout) = timeout {
+    let (index, states_searched, removal_orders) = if let Some(timeout) = timeout {
         // If a timeout is provided, we will search within an asynchronous task
         // that can be interrupted after the specified duration (see below). To
         // avoid subsequent scope issues, make copies of various variables.
@@ -433,7 +435,27 @@ pub fn index_search(
         (index, Some(states_searched), removal_orders)
     };
 
-    (index as u32, matches.len() as u32, states_searched)
+    // Generate at most the given number of minimum assembly pathways from the
+    // returned match removal orders.
+    let mut pathways = Vec::<Pathway>::new();
+    if let Some(max_pathways) = max_pathways {
+        if let Some(mut removal_orders) = removal_orders {
+            for (ix, removal_order) in removal_orders.drain().enumerate() {
+                if ix >= max_pathways {
+                    break;
+                } else {
+                    pathways.push(Pathway::new(mol, &matches, &removal_order));
+                }
+            }
+        }
+    }
+
+    (
+        index as u32,
+        matches.len() as u32,
+        states_searched,
+        pathways,
+    )
 }
 
 /// Compute a molecule's assembly index using an efficient default strategy.
@@ -461,7 +483,7 @@ pub fn index_search(
 pub fn index(mol: &Molecule) -> u32 {
     index_search(
         mol,
-        None,
+        None, // Run without a timeout.
         CanonizeMode::TreeNauty,
         ParallelMode::DepthOne,
         MemoizeMode::CanonIndex,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -287,17 +287,18 @@ pub fn recurse_index_search(
 /// the order they appear in the `bounds` slice. It is generally better to
 /// provide bounds that are quick to compute first.
 ///
-/// If `max_pathways` is `None`, skip minimum assembly pathway reconstruction.
-/// Otherwise, reconstruct all such pathways from the completed search results
-/// if `max_pathways == 0` or at most `max_pathways` such pathways otherwise.
+/// If `max_pathways` is `None`, skip minimum assembly pathway reconstruction. Otherwise,
+/// reconstruct all such pathways from the completed search results if `max_pathways == 0` or at
+/// most `max_pathways` such pathways otherwise. Reconstructing minimum assembly pathways incurs a
+/// 5&ndash;20% runtime overhead; disable for faster assembly index calculation.
 ///
 /// The results returned are:
 /// - The molecule's `u32` assembly index (or an upper bound if timed out).
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
-/// - A vector of the molecule's minimum assembly [`Pathway`]s that is nonempty
-///   if and only if search did not time out and `max_pathways` is not `None`.
+/// - A vector of the molecule's minimum assembly [`Pathway`]s that is nonempty if and only if
+///   search did not time out and `max_pathways` is not `None`.
 ///
 /// If `parallel_mode` is set to anything other than [`ParallelMode::None`], the total number of
 /// assembly states searched and the minimum assembly pathways reconstructed are nondeterministic.

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -22,7 +22,7 @@
 //! pathways, see [`index_search`].
 
 use std::{
-    collections::HashSet,
+    collections::BTreeSet,
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc,
@@ -161,17 +161,16 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<
 /// - `bounds`: The list of bounding strategies to apply.
 /// - `cache`: Memoization cache storing previously searched assembly states.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
-/// - `collect_removal_orders`: `true` iff match removal orders should be
-///   collected for later assembly pathway reconstruction.
+/// - `max_pathways`: The number of distinct match removal orders attaining the best assembly index
+///   bound to collect; `0` for all, `x > 0` for at most `x`, or `None` for none.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: An updated upper bound on the assembly index. (Note: If this
 ///   state is pruned by bounds or deemed redundant by memoization, then the
 ///   upper bound returned is unchanged.)
 /// - `usize`: The number of assembly states searched.
-/// - `Option<HashSet<Vec<usize>>>`: A set of assembly states' match removal
-///   orders that attain the updated assembly index upper bound, or `None` if
-///   `collect_removal_orders == false`.
+/// - `BTreeSet<Vec<usize>>`: A set of assembly states' match removal orders that attain the
+///   updated assembly index upper bound. Nonempty iff `max_pathways` is not `None`.
 #[allow(clippy::too_many_arguments)]
 pub fn recurse_index_search(
     mol: &Molecule,
@@ -181,8 +180,8 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
-    collect_removal_orders: bool,
-) -> (usize, usize, Option<HashSet<Vec<usize>>>) {
+    max_pathways: Option<usize>,
+) -> (usize, usize, BTreeSet<Vec<usize>>) {
     // If any bounds would prune this assembly state or if memoization is
     // enabled and this assembly state is preempted by the cached state, halt.
     if state_bounds(mol, state, best_index.load(Relaxed), bounds) || cache.memoize_state(mol, state)
@@ -190,10 +189,10 @@ pub fn recurse_index_search(
         return (
             state.index(),
             1,
-            if collect_removal_orders {
-                Some(HashSet::from([state.removal_order().clone()]))
+            if max_pathways.is_some() {
+                BTreeSet::from([state.removal_order().clone()])
             } else {
-                None
+                BTreeSet::<Vec<usize>>::new()
             },
         );
     }
@@ -205,7 +204,7 @@ pub fn recurse_index_search(
 
     // Define a closure that handles recursing to a new assembly state based on
     // the given match.
-    let recurse_on_match = |match_ix: usize| -> (usize, usize, Option<HashSet<Vec<usize>>>) {
+    let recurse_on_match = |match_ix: usize| -> (usize, usize, BTreeSet<Vec<usize>>) {
         let (h1, h2) = matches.match_fragments(match_ix);
         let fragments = fragments(mol, &intermediate_frags, h1, h2);
 
@@ -226,25 +225,24 @@ pub fn recurse_index_search(
             bounds,
             &mut cache.clone(),
             new_parallel,
-            collect_removal_orders,
+            max_pathways,
         )
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.
-    #[allow(clippy::type_complexity)]
-    let results: Vec<(usize, usize, Option<HashSet<Vec<usize>>>)> =
-        if parallel_mode == ParallelMode::None {
-            matches_to_remove
-                .iter()
-                .map(|match_ix| recurse_on_match(*match_ix))
-                .collect()
-        } else {
-            matches_to_remove
-                .iter()
-                .par_bridge()
-                .map(|match_ix| recurse_on_match(*match_ix))
-                .collect()
-        };
+    let results: Vec<(usize, usize, BTreeSet<Vec<usize>>)> = if parallel_mode == ParallelMode::None
+    {
+        matches_to_remove
+            .iter()
+            .map(|match_ix| recurse_on_match(*match_ix))
+            .collect()
+    } else {
+        matches_to_remove
+            .iter()
+            .par_bridge()
+            .map(|match_ix| recurse_on_match(*match_ix))
+            .collect()
+    };
 
     // Compute the best assembly index bound and the total number of descendant
     // states searched across all children assembly states.
@@ -256,25 +254,25 @@ pub fn recurse_index_search(
 
     // Collect all descendant match removal orders attaining the best assembly
     // index bound across children assembly states.
-    if collect_removal_orders {
-        let mut best_removal_orders = if state.index() == best_child_index {
-            HashSet::from([state.removal_order().clone()])
-        } else {
-            HashSet::<Vec<usize>>::new()
-        };
-        for r in results {
+    let mut best_removal_orders = BTreeSet::<Vec<usize>>::new();
+    if let Some(max_pathways) = max_pathways {
+        if state.index() == best_child_index {
+            best_removal_orders.insert(state.removal_order().clone());
+        }
+        for mut r in results {
             if r.0 == best_child_index {
-                best_removal_orders.extend(r.2.unwrap());
+                if max_pathways == 0 || best_removal_orders.len() + r.2.len() <= max_pathways {
+                    best_removal_orders.extend(r.2)
+                } else {
+                    while best_removal_orders.len() < max_pathways {
+                        best_removal_orders.insert(r.2.pop_first().unwrap());
+                    }
+                    break; // Collected desired number of removal orders; no need to check more.
+                }
             }
         }
-        (
-            best_child_index,
-            states_searched + 1,
-            Some(best_removal_orders),
-        )
-    } else {
-        (best_child_index, states_searched + 1, None)
     }
+    (best_child_index, states_searched + 1, best_removal_orders)
 }
 
 /// Compute a molecule's assembly index and related information using a
@@ -536,7 +534,7 @@ pub fn index_search(
                     &bounds,
                     &mut cache,
                     parallel_mode,
-                    max_pathways.is_some(),
+                    max_pathways,
                 ));
             });
             tktimeout(Duration::from_millis(timeout), recv).await
@@ -549,7 +547,11 @@ pub fn index_search(
             Ok(Ok((index, states_searched, removal_orders))) => {
                 (index, Some(states_searched), removal_orders)
             }
-            Err(_) => (best_index.load(Relaxed), None, None),
+            Err(_) => (
+                best_index.load(Relaxed),
+                None,
+                BTreeSet::<Vec<usize>>::new(),
+            ),
             _ => panic!("An unexpected error occurred in async index_search"),
         }
     } else {
@@ -562,7 +564,7 @@ pub fn index_search(
             bounds,
             &mut cache,
             parallel_mode,
-            max_pathways.is_some(),
+            max_pathways,
         );
         (index, Some(states_searched), removal_orders)
     };
@@ -571,19 +573,11 @@ pub fn index_search(
     // returned match removal orders.
     let mut pathways = Vec::<Pathway>::new();
     if let Some(max_pathways) = max_pathways {
-        if let Some(removal_orders) = removal_orders {
-            // Sort the removal orders, which guarantees deterministic output
-            // if search returns the same set of removal orders.
-            let mut removal_orders = Vec::from_iter(removal_orders);
-            removal_orders.sort();
-
-            // Extract the desired number of pathways.
-            for (ix, removal_order) in removal_orders.iter().enumerate() {
-                if max_pathways > 0 && ix >= max_pathways {
-                    break;
-                } else {
-                    pathways.push(Pathway::new(mol, &matches, removal_order));
-                }
+        for (ix, removal_order) in removal_orders.iter().enumerate() {
+            if max_pathways > 0 && ix >= max_pathways {
+                break;
+            } else {
+                pathways.push(Pathway::new(mol, &matches, removal_order));
             }
         }
     }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -290,7 +290,7 @@ pub fn recurse_index_search(
 /// If `max_pathways` is `None`, skip minimum assembly pathway reconstruction. Otherwise,
 /// reconstruct all such pathways from the completed search results if `max_pathways == 0` or at
 /// most `max_pathways` such pathways otherwise. Reconstructing minimum assembly pathways incurs a
-/// 5&ndash;20% runtime overhead; disable for faster assembly index calculation.
+/// 5-20% runtime overhead; disable for faster assembly index calculation.
 ///
 /// The results returned are:
 /// - The molecule's `u32` assembly index (or an upper bound if timed out).

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -17,6 +17,9 @@
 //! # Ok(())
 //! # }
 //! ```
+//! To customize assembly index calculation beyond the default strategy, set a
+//! timeout for long-running calculations, and/or reconstruct minimum assembly
+//! pathways, see [`index_search`].
 
 use std::{
     collections::HashSet,
@@ -293,9 +296,14 @@ pub fn recurse_index_search(
 /// - The molecule's `u32` number of edge-disjoint isomorphic subgraph pairs.
 /// - The `usize` total number of assembly [`State`]s searched if search
 ///   completes, and `None` otherwise (i.e., if search timed out).
-/// - A vector of of minimum assembly [`Pathway`]s.
+/// - A vector of of minimum assembly [`Pathway`]s that is nonempty if and only
+///   if search did not time out and `max_pathways` is not `None`.
 ///
-/// # Example
+/// # Customizing Assembly Index Search Options
+///
+/// The two examples below show different customizations of the assembly index
+/// search options, enabling/disabling parallelism and memoization and choosing
+/// different combinations of bounds.
 /// ```
 /// # use std::{fs, path::PathBuf};
 /// use assembly_theory::{
@@ -319,10 +327,10 @@ pub fn recurse_index_search(
 ///     &anthracene,
 ///     None,
 ///     CanonizeMode::TreeNauty,
-///     ParallelMode::None,
-///     MemoizeMode::None,
-///     KernelMode::None,
-///     &[],
+///     ParallelMode::None,      // Disable parallelism.
+///     MemoizeMode::None,       // Disable memoization.
+///     KernelMode::None,        // Disable kernelization.
+///     &[],                     // Do not use any bounds.
 ///     None,
 /// );
 /// assert_eq!(slow_index, 6);
@@ -340,19 +348,136 @@ pub fn recurse_index_search(
 ///     None,
 /// );
 /// assert_eq!(fast_index, 6);
+/// # Ok(())
+/// # }
+/// ```
 ///
-/// // Limit search to 1 ms, which should time out.
-/// let (index_bound, _, states_searched, _) = index_search(
+/// # Setting a Timeout for Long Calculations
+///
+/// Assembly index calculation can be slow on large molecules, even with search
+/// optimizations enabled. If `timeout` is set, two outcomes are possible:
+/// 1. Search completes before the timeout and everything behaves as usual.
+/// 2. The timeout is reached before search completes, search is interrupted,
+///    and the best upper bound on the assembly index found so far is returned.
+///    The number of states searched and assembly pathways are not returned.
+/// ```
+/// # use std::{fs, path::PathBuf};
+/// # use assembly_theory::{
+/// #     assembly::{index_search, ParallelMode},
+/// #     bounds::Bound,
+/// #     canonize::CanonizeMode,
+/// #     kernels::KernelMode,
+/// #     loader::parse_molfile_str,
+/// #     memoize::MemoizeMode,
+/// # };
+/// #
+/// # fn main() -> Result<(), std::io::Error> {
+/// # let path = PathBuf::from(format!("./data/checks/anthracene.mol"));
+/// # let molfile = fs::read_to_string(path)?;
+/// # let anthracene = parse_molfile_str(&molfile).expect("Parsing failure.");
+/// #
+/// // Limit search to 10 s, which is plenty for search to complete as usual,
+/// // even with some search optimizations disabled.
+/// let (true_index, num_matches, states_searched, pathways) = index_search(
 ///     &anthracene,
-///     Some(1),
+///     Some(10000), // Set a 10 s timeout.
 ///     CanonizeMode::TreeNauty,
 ///     ParallelMode::None,
 ///     MemoizeMode::None,
 ///     KernelMode::None,
-///     &[],
-///     None,
+///     &[Bound::Int, Bound::MatchableEdges],
+///     Some(1),
 /// );
-/// assert!(index_bound >= fast_index && states_searched == None);
+/// assert_eq!(true_index, 6);
+/// assert_eq!(num_matches, 466);
+/// assert_eq!(states_searched, Some(491));
+/// assert_eq!(pathways.len(), 1);
+///
+/// // Limit search to 1 ms, which will time out without more optimizations.
+/// let (index_bound, num_matches, states_searched, pathways) = index_search(
+///     &anthracene,
+///     Some(1), // Set a 1 ms timeout.
+///     CanonizeMode::TreeNauty,
+///     ParallelMode::None,
+///     MemoizeMode::None,
+///     KernelMode::None,
+///     &[Bound::Int, Bound::MatchableEdges],
+///     Some(1),
+/// );
+/// assert!(index_bound >= true_index); // Index is an upper bound on timeout.
+/// assert_eq!(num_matches, 466);       // The number of matches is unaffected.
+/// assert_eq!(states_searched, None);  // States searched is not computed on timeout.
+/// assert_eq!(pathways.len(), 0);      // Pathways are not computed on timeout.
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Reconstructing Minimum Assembly Pathways
+///
+/// An assembly [`Pathway`] records the fragment join operations producing the
+/// target molecule. Set `max_pathways` to `Some(0)` to reconstruct all minimum
+/// assembly pathways discovered by the search process, `Some(n)` for the first
+/// `n` such pathways, or `None` to disable pathway reconstruction. See
+/// [`Pathway::dag`] for details on the pathway data structure.
+///
+/// Note that the definition of `Some(0)`'s behavior is very carefully worded:
+/// it finds all minimum assembly pathways *discovered by the search process*.
+/// This is not to be taken as *all possible minimum assembly pathways*. When
+/// search optimizations like parallelism, memoization, and bounding are used,
+/// search prunes pathways that cannot yield a better assembly index. This may
+/// include pathways that yield an *equal* (i.e., also minimum) assembly index.
+/// Once pruned, these pathways will not survive to pathway reconstruction.
+/// ```
+/// # use std::{fs, path::PathBuf};
+/// # use assembly_theory::{
+/// #     assembly::{index_search, ParallelMode},
+/// #     bounds::Bound,
+/// #     canonize::CanonizeMode,
+/// #     kernels::KernelMode,
+/// #     loader::parse_molfile_str,
+/// #     memoize::MemoizeMode,
+/// # };
+/// #
+/// # fn main() -> Result<(), std::io::Error> {
+/// # let path = PathBuf::from(format!("./data/checks/anthracene.mol"));
+/// # let molfile = fs::read_to_string(path)?;
+/// # let anthracene = parse_molfile_str(&molfile).expect("Parsing failure.");
+/// #
+/// // Reconstruct a minimum assembly pathway discovered during search.
+/// let (_, _, _, pathways) = index_search(
+///     &anthracene,
+///     None,
+///     CanonizeMode::TreeNauty,
+///     ParallelMode::None,        // Disable parallelism for determinism.
+///     MemoizeMode::CanonIndex,
+///     KernelMode::None,
+///     &[Bound::Log, Bound::Int],
+///     Some(1),                   // Reconstuct one pathway.
+/// );
+/// let pathway_str = r#"digraph {
+///     0 [ label = "{14}" ]
+///     1 [ label = "{15}" ]
+///     2 [ label = "{14, 15}" ]
+///     3 [ label = "{7, 14, 15}" ]
+///     4 [ label = "{6, 7, 14, 15}" ]
+///     5 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+///     6 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+///     7 [ label = "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}" ]
+///     0 -> 2 [ label = "{14}" ]
+///     1 -> 2 [ label = "{15}" ]
+///     0 -> 3 [ label = "{7}" ]
+///     2 -> 3 [ label = "{14, 15}" ]
+///     1 -> 4 [ label = "{6}" ]
+///     3 -> 4 [ label = "{7, 14, 15}" ]
+///     4 -> 5 [ label = "{6, 7, 14, 15}" ]
+///     3 -> 5 [ label = "{3, 4, 5}" ]
+///     2 -> 6 [ label = "{2, 13}" ]
+///     5 -> 6 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+///     6 -> 7 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+///     5 -> 7 [ label = "{0, 1, 8, 9, 10, 11, 12}" ]
+/// }
+/// "#;
+/// assert_eq!(format!("{}", pathways[0]), pathway_str);
 /// # Ok(())
 /// # }
 /// ```
@@ -439,8 +564,14 @@ pub fn index_search(
     // returned match removal orders.
     let mut pathways = Vec::<Pathway>::new();
     if let Some(max_pathways) = max_pathways {
-        if let Some(mut removal_orders) = removal_orders {
-            for (ix, removal_order) in removal_orders.drain().enumerate() {
+        if let Some(removal_orders) = removal_orders {
+            // Sort the removal orders, which guarantees deterministic output
+            // if search returns the same set of removal orders.
+            let mut removal_orders = Vec::from_iter(removal_orders);
+            removal_orders.sort();
+
+            // Extract the desired number of pathways.
+            for (ix, removal_order) in removal_orders.iter().enumerate() {
                 if max_pathways > 0 && ix >= max_pathways {
                     break;
                 } else {
@@ -460,8 +591,9 @@ pub fn index_search(
 
 /// Compute a molecule's assembly index using an efficient default strategy.
 ///
-/// To customize assembly index calculation beyond the default strategy and/or
-/// reconstruct minimum assembly pathways, see [`index_search`].
+/// To customize assembly index calculation beyond the default strategy, set a
+/// timeout for long-running calculations, and/or reconstruct minimum assembly
+/// pathways, see [`index_search`].
 ///
 /// # Example
 /// ```

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -19,6 +19,7 @@
 //! ```
 
 use std::{
+    collections::HashSet,
     sync::{
         atomic::{AtomicUsize, Ordering::Relaxed},
         Arc,
@@ -162,6 +163,8 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<
 ///   state is pruned by bounds or deemed redundant by memoization, then the
 ///   upper bound returned is unchanged.)
 /// - `usize`: The number of assembly states searched.
+/// - `HashSet<Vec<usize>>`: A set of assembly states' match removal orders
+///   that attain the updated assembly index upper bound.
 pub fn recurse_index_search(
     mol: &Molecule,
     matches: &Matches,
@@ -170,12 +173,16 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
-) -> (usize, usize) {
+) -> (usize, usize, HashSet<Vec<usize>>) {
     // If any bounds would prune this assembly state or if memoization is
     // enabled and this assembly state is preempted by the cached state, halt.
     if state_bounds(mol, state, best_index.load(Relaxed), bounds) || cache.memoize_state(mol, state)
     {
-        return (state.index(), 1);
+        return (
+            state.index(),
+            1,
+            HashSet::from([state.removal_order().clone()]),
+        );
     }
 
     // Generate a list of matches (i.e., pairs of edge-disjoint, isomorphic
@@ -185,7 +192,7 @@ pub fn recurse_index_search(
 
     // Define a closure that handles recursing to a new assembly state based on
     // the given match.
-    let recurse_on_match = |match_ix: usize| -> (usize, usize) {
+    let recurse_on_match = |match_ix: usize| -> (usize, usize, HashSet<Vec<usize>>) {
         let (h1, h2) = matches.match_fragments(match_ix);
         let fragments = fragments(mol, &intermediate_frags, h1, h2);
 
@@ -210,7 +217,7 @@ pub fn recurse_index_search(
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.
-    let results: Vec<(usize, usize)> = if parallel_mode == ParallelMode::None {
+    let results: Vec<(usize, usize, HashSet<Vec<usize>>)> = if parallel_mode == ParallelMode::None {
         matches_to_remove
             .iter()
             .map(|match_ix| recurse_on_match(*match_ix))
@@ -231,7 +238,20 @@ pub fn recurse_index_search(
     // Update the globally best assembly index bound found so far.
     best_index.fetch_min(best_child_index, Relaxed);
 
-    (best_child_index, states_searched + 1)
+    // Collect all descendant match removal orders attaining the best assembly
+    // index bound across children assembly states.
+    let mut best_removal_orders = if state.index() == best_child_index {
+        HashSet::from([state.removal_order().clone()])
+    } else {
+        HashSet::<Vec<usize>>::new()
+    };
+    for r in results {
+        if r.0 == best_child_index {
+            best_removal_orders.extend(r.2);
+        }
+    }
+
+    (best_child_index, states_searched + 1, best_removal_orders)
 }
 
 /// Compute a molecule's assembly index and related information using a
@@ -367,14 +387,14 @@ pub fn index_search(
         // index. Otherwise, return the best upper bound on the assembly index
         // found before timing out.
         let (index, states_searched) = match result {
-            Ok(Ok((index, states_searched))) => (index, Some(states_searched)),
+            Ok(Ok((index, states_searched, removal_orders))) => (index, Some(states_searched)),
             Err(_) => (best_index.load(Relaxed), None),
             _ => panic!("An unexpected error occurred in async index_search"),
         };
         (index as u32, num_matches as u32, states_searched)
     } else {
         // Otherwise, if no timeout is provided, run the search normally.
-        let (index, states_searched) = recurse_index_search(
+        let (index, states_searched, removal_orders) = recurse_index_search(
             mol,
             &matches,
             &state,

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -299,6 +299,9 @@ pub fn recurse_index_search(
 /// - A vector of the molecule's minimum assembly [`Pathway`]s that is nonempty
 ///   if and only if search did not time out and `max_pathways` is not `None`.
 ///
+/// If `parallel_mode` is set to anything other than [`ParallelMode::None`], the total number of
+/// assembly states searched and the minimum assembly pathways reconstructed are nondeterministic.
+///
 /// # Examples
 ///
 /// ## Customizing Assembly Index Search Options

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -375,7 +375,6 @@ pub fn index_search(
 
     // Enumerate matches (i.e., pairs of edge-disjoint isomorphic fragments).
     let matches = Matches::new(mol, canonize_mode);
-    let num_matches = matches.len();
 
     // Use an `Arc` to track the best assembly index across parallel threads.
     let best_index = Arc::new(AtomicUsize::from(mol.graph().edge_count() - 1));
@@ -385,8 +384,9 @@ pub fn index_search(
         // If a timeout is provided, we will search within an asynchronous task
         // that can be interrupted after the specified duration (see below). To
         // avoid subsequent scope issues, make copies of various variables.
-        let best_index_copy = best_index.clone();
         let mol = mol.clone();
+        let matches = matches.clone();
+        let best_index_copy = best_index.clone();
         let bounds = bounds.to_vec();
 
         // Search within a dedicated asynchronous runtime.
@@ -433,7 +433,7 @@ pub fn index_search(
         (index, Some(states_searched), removal_orders)
     };
 
-    (index as u32, num_matches as u32, states_searched)
+    (index as u32, matches.len() as u32, states_searched)
 }
 
 /// Compute a molecule's assembly index using an efficient default strategy.

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -157,14 +157,17 @@ fn fragments(mol: &Molecule, state: &[BitSet], h1: &BitSet, h2: &BitSet) -> Vec<
 /// - `bounds`: The list of bounding strategies to apply.
 /// - `cache`: Memoization cache storing previously searched assembly states.
 /// - `parallel_mode`: The parallelism mode for this state's match iteration.
+/// - `collect_removal_orders`: `true` iff match removal orders should be
+///   collected for later assembly pathway reconstruction.
 ///
 /// Returns, from this assembly state and any of its descendents:
 /// - `usize`: An updated upper bound on the assembly index. (Note: If this
 ///   state is pruned by bounds or deemed redundant by memoization, then the
 ///   upper bound returned is unchanged.)
 /// - `usize`: The number of assembly states searched.
-/// - `HashSet<Vec<usize>>`: A set of assembly states' match removal orders
-///   that attain the updated assembly index upper bound.
+/// - `Option<HashSet<Vec<usize>>>`: A set of assembly states' match removal
+///   orders that attain the updated assembly index upper bound, or `None` if
+///   `collect_removal_orders == false`.
 pub fn recurse_index_search(
     mol: &Molecule,
     matches: &Matches,
@@ -173,7 +176,8 @@ pub fn recurse_index_search(
     bounds: &[Bound],
     cache: &mut Cache,
     parallel_mode: ParallelMode,
-) -> (usize, usize, HashSet<Vec<usize>>) {
+    collect_removal_orders: bool,
+) -> (usize, usize, Option<HashSet<Vec<usize>>>) {
     // If any bounds would prune this assembly state or if memoization is
     // enabled and this assembly state is preempted by the cached state, halt.
     if state_bounds(mol, state, best_index.load(Relaxed), bounds) || cache.memoize_state(mol, state)
@@ -181,7 +185,11 @@ pub fn recurse_index_search(
         return (
             state.index(),
             1,
-            HashSet::from([state.removal_order().clone()]),
+            if collect_removal_orders {
+                Some(HashSet::from([state.removal_order().clone()]))
+            } else {
+                None
+            },
         );
     }
 
@@ -192,7 +200,7 @@ pub fn recurse_index_search(
 
     // Define a closure that handles recursing to a new assembly state based on
     // the given match.
-    let recurse_on_match = |match_ix: usize| -> (usize, usize, HashSet<Vec<usize>>) {
+    let recurse_on_match = |match_ix: usize| -> (usize, usize, Option<HashSet<Vec<usize>>>) {
         let (h1, h2) = matches.match_fragments(match_ix);
         let fragments = fragments(mol, &intermediate_frags, h1, h2);
 
@@ -213,22 +221,24 @@ pub fn recurse_index_search(
             bounds,
             &mut cache.clone(),
             new_parallel,
+            collect_removal_orders,
         )
     };
 
     // Use the iterator type corresponding to the specified parallelism mode.
-    let results: Vec<(usize, usize, HashSet<Vec<usize>>)> = if parallel_mode == ParallelMode::None {
-        matches_to_remove
-            .iter()
-            .map(|match_ix| recurse_on_match(*match_ix))
-            .collect()
-    } else {
-        matches_to_remove
-            .iter()
-            .par_bridge()
-            .map(|match_ix| recurse_on_match(*match_ix))
-            .collect()
-    };
+    let results: Vec<(usize, usize, Option<HashSet<Vec<usize>>>)> =
+        if parallel_mode == ParallelMode::None {
+            matches_to_remove
+                .iter()
+                .map(|match_ix| recurse_on_match(*match_ix))
+                .collect()
+        } else {
+            matches_to_remove
+                .iter()
+                .par_bridge()
+                .map(|match_ix| recurse_on_match(*match_ix))
+                .collect()
+        };
 
     // Compute the best assembly index bound and the total number of descendant
     // states searched across all children assembly states.
@@ -240,18 +250,25 @@ pub fn recurse_index_search(
 
     // Collect all descendant match removal orders attaining the best assembly
     // index bound across children assembly states.
-    let mut best_removal_orders = if state.index() == best_child_index {
-        HashSet::from([state.removal_order().clone()])
-    } else {
-        HashSet::<Vec<usize>>::new()
-    };
-    for r in results {
-        if r.0 == best_child_index {
-            best_removal_orders.extend(r.2);
+    if collect_removal_orders {
+        let mut best_removal_orders = if state.index() == best_child_index {
+            HashSet::from([state.removal_order().clone()])
+        } else {
+            HashSet::<Vec<usize>>::new()
+        };
+        for r in results {
+            if r.0 == best_child_index {
+                best_removal_orders.extend(r.2.unwrap());
+            }
         }
+        (
+            best_child_index,
+            states_searched + 1,
+            Some(best_removal_orders),
+        )
+    } else {
+        (best_child_index, states_searched + 1, None)
     }
-
-    (best_child_index, states_searched + 1, best_removal_orders)
 }
 
 /// Compute a molecule's assembly index and related information using a
@@ -378,6 +395,7 @@ pub fn index_search(
                     &bounds,
                     &mut cache,
                     parallel_mode,
+                    true,
                 ));
             });
             tktimeout(Duration::from_millis(timeout), recv).await
@@ -402,6 +420,7 @@ pub fn index_search(
             bounds,
             &mut cache,
             parallel_mode,
+            true,
         );
         (index as u32, matches.len() as u32, Some(states_searched))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod kernels;
 pub mod matches;
 pub mod memoize;
 mod nauty;
+pub mod pathway;
 pub mod state;
 mod vf3;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,12 @@ struct Cli {
     /// Strategy for performing graph kernelization during the search phase.
     #[arg(long, value_enum, default_value_t = KernelMode::None)]
     kernel: KernelMode,
+
+    /// Maximum number of minimum assembly pathways to reconstruct, or `None`
+    /// (default) to disable pathway reconstruction. Set this option to 0 to
+    /// reconstruct all minimum assembly pathways.
+    #[arg(long)]
+    pathways: Option<usize>,
 }
 
 #[derive(Args, Debug)]
@@ -109,7 +115,7 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, num_matches, states_searched) = index_search(
+    let (index, num_matches, states_searched, _) = index_search(
         &mol,
         cli.timeout,
         cli.canonize,
@@ -117,7 +123,7 @@ fn main() -> Result<()> {
         cli.memoize,
         cli.kernel,
         boundlist,
-        None,
+        cli.pathways,
     );
 
     // Print final output, depending on --verbose.

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn main() -> Result<()> {
         cli.memoize,
         cli.kernel,
         boundlist,
+        None,
     );
 
     // Print final output, depending on --verbose.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,11 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = KernelMode::None)]
     kernel: KernelMode,
 
-    /// Maximum number of minimum assembly pathways to reconstruct, or `None`
-    /// (default) to disable pathway reconstruction. Set this option to 0 to
-    /// reconstruct all minimum assembly pathways found during search. If not
-    /// `None`, output will automatically use --verbose formatting.
+    /// Maximum number of minimum assembly pathways to reconstruct, or `None` (default) to disable
+    /// pathway reconstruction. Set this option to 0 to reconstruct all minimum assembly pathways
+    /// found during search. If not `None`, output will automatically use --verbose formatting.
+    /// Reconstructing minimum assembly pathways incurs a 5-20% runtime overhead; disable for
+    /// faster assembly index calculation.
     #[arg(long)]
     pathways: Option<usize>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,15 +25,16 @@ struct Cli {
     #[arg(long)]
     depth: bool,
 
-    /// Print the assembly index, assembly depth, number of edge-disjoint
-    /// isomorphic subgraph pairs, and size of the search space. Note that the
-    /// search space size is nondeterministic owing to some `HashMap` details.
+    /// Print the molecule's assembly index, number of matches (edge-disjoint
+    /// isomorphic subgraph pairs), number of states searched, and assembly
+    /// pathways (if `--pathways` is given). When using parallelism, the number
+    /// of states searched is nondeterministic.
     #[arg(long)]
     verbose: bool,
 
     /// Timeout duration in milliseconds after which search is stopped and the
-    /// best assembly index found so far is returned, or `None` if search is
-    /// run until the true assembly index is found.
+    /// best assembly index found so far is returned, or `None` (default) if
+    /// search is run until the true assembly index is found.
     #[arg(long)]
     timeout: Option<u64>,
 
@@ -59,7 +60,7 @@ struct Cli {
 
     /// Maximum number of minimum assembly pathways to reconstruct, or `None`
     /// (default) to disable pathway reconstruction. Set this option to 0 to
-    /// reconstruct all minimum assembly pathways.
+    /// reconstruct all minimum assembly pathways found during search.
     #[arg(long)]
     pathways: Option<usize>,
 }
@@ -115,7 +116,7 @@ fn main() -> Result<()> {
     };
 
     // Call index calculation with all the various options.
-    let (index, num_matches, states_searched, _) = index_search(
+    let (index, num_matches, states_searched, pathways) = index_search(
         &mol,
         cli.timeout,
         cli.canonize,
@@ -126,22 +127,29 @@ fn main() -> Result<()> {
         cli.pathways,
     );
 
-    // Print final output, depending on --verbose.
+    // Print final output, depending on --verbose and timeout status.
     match (cli.verbose, states_searched) {
         // Found the exact assembly index.
         (true, Some(states_searched)) => {
             println!("Assembly Index:  {index}");
             println!("Matches:         {num_matches}");
             println!("States Searched: {states_searched}");
+            for (i, pathway) in pathways.iter().enumerate() {
+                println!("Pathway {i}: {pathway}");
+            }
         }
         (false, Some(_)) => {
             println!("{index}");
+            for pathway in pathways {
+                println!("{pathway}");
+            }
         }
         // Search timed out and returned an upper bound.
         (true, None) => {
             println!("Assembly Index:  <= {index} (timed out)");
             println!("Matches:         {num_matches}");
             println!("States Searched: not computed on timeout");
+            println!("Pathways:        not computed on timeout");
         }
         (false, None) => {
             println!("<= {index} (timed out)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,21 +144,19 @@ fn main() -> Result<()> {
             // Timed out but not verbose.
             println!("<= {index} (timed out)");
         }
-    } else {
-        if cli.verbose || !cli.pathways.is_none() {
-            // Did not time out AND [verbose OR at least one pathway].
-            println!("Assembly Index:  {index}");
-            println!("Matches:         {num_matches}");
-            println!("States Searched: {}", states_searched.unwrap());
-            println!("Pathways Found:  {}", pathways.len());
-            println!("\nMolecule Graph: {}", mol.info());
-            for (i, pathway) in pathways.iter().enumerate() {
-                println!("Pathway {i}: {pathway}");
-            }
-        } else {
-            // Did not time out and only assembly index is desired.
-            println!("{index}");
+    } else if cli.verbose || cli.pathways.is_some() {
+        // Did not time out AND [verbose OR at least one pathway].
+        println!("Assembly Index:  {index}");
+        println!("Matches:         {num_matches}");
+        println!("States Searched: {}", states_searched.unwrap());
+        println!("Pathways Found:  {}", pathways.len());
+        println!("\nMolecule Graph: {}", mol.info());
+        for (i, pathway) in pathways.iter().enumerate() {
+            println!("Pathway {i}: {pathway}");
         }
+    } else {
+        // Did not time out and only assembly index is desired.
+        println!("{index}");
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,7 @@ struct Cli {
 
     /// Print the molecule's assembly index, number of matches (edge-disjoint
     /// isomorphic subgraph pairs), number of states searched, molecule graph
-    /// structure, and assembly pathways (if `--pathways` is given). When using
-    /// parallelism, number of states searched and assembly pathways are
-    /// nondeterministic.
+    /// structure, and assembly pathways (if --pathways is given).
     #[arg(long)]
     verbose: bool,
 
@@ -43,7 +41,9 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = CanonizeMode::TreeNauty)]
     canonize: CanonizeMode,
 
-    /// Parallelization strategy for the search phase.
+    /// Parallelism strategy for the search phase. When parallelism is enabled, the number of
+    /// states searched (visible with --verbose) and the minimum assembly pathways reconstructed
+    /// (obtained with --pathways) are nondeterministic.
     #[arg(long, value_enum, default_value_t = ParallelMode::DepthOne)]
     parallel: ParallelMode,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,10 @@ struct Cli {
     depth: bool,
 
     /// Print the molecule's assembly index, number of matches (edge-disjoint
-    /// isomorphic subgraph pairs), number of states searched, and assembly
-    /// pathways (if `--pathways` is given). When using parallelism, the number
-    /// of states searched is nondeterministic.
+    /// isomorphic subgraph pairs), number of states searched, molecule graph
+    /// structure, and assembly pathways (if `--pathways` is given). When using
+    /// parallelism, number of states searched and assembly pathways are
+    /// nondeterministic.
     #[arg(long)]
     verbose: bool,
 
@@ -60,7 +61,8 @@ struct Cli {
 
     /// Maximum number of minimum assembly pathways to reconstruct, or `None`
     /// (default) to disable pathway reconstruction. Set this option to 0 to
-    /// reconstruct all minimum assembly pathways found during search.
+    /// reconstruct all minimum assembly pathways found during search. If not
+    /// `None`, output will automatically use --verbose formatting.
     #[arg(long)]
     pathways: Option<usize>,
 }
@@ -127,32 +129,34 @@ fn main() -> Result<()> {
         cli.pathways,
     );
 
-    // Print final output, depending on --verbose and timeout status.
-    match (cli.verbose, states_searched) {
-        // Found the exact assembly index.
-        (true, Some(states_searched)) => {
-            println!("Assembly Index:  {index}");
-            println!("Matches:         {num_matches}");
-            println!("States Searched: {states_searched}");
-            for (i, pathway) in pathways.iter().enumerate() {
-                println!("Pathway {i}: {pathway}");
-            }
-        }
-        (false, Some(_)) => {
-            println!("{index}");
-            for pathway in pathways {
-                println!("{pathway}");
-            }
-        }
-        // Search timed out and returned an upper bound.
-        (true, None) => {
+    // Print final output depending on --verbose, pathways, and timeout status.
+    let timed_out = states_searched.is_none();
+    if timed_out {
+        if cli.verbose {
+            // Timed out and verbose.
             println!("Assembly Index:  <= {index} (timed out)");
             println!("Matches:         {num_matches}");
             println!("States Searched: not computed on timeout");
-            println!("Pathways:        not computed on timeout");
-        }
-        (false, None) => {
+            println!("Pathways Found:  not computed on timeout");
+            println!("\nMolecule Graph: {}", mol.info());
+        } else {
+            // Timed out but not verbose.
             println!("<= {index} (timed out)");
+        }
+    } else {
+        if cli.verbose || !cli.pathways.is_none() {
+            // Did not time out AND [verbose OR at least one pathway].
+            println!("Assembly Index:  {index}");
+            println!("Matches:         {num_matches}");
+            println!("States Searched: {}", states_searched.unwrap());
+            println!("Pathways Found:  {}", pathways.len());
+            println!("\nMolecule Graph: {}", mol.info());
+            for (i, pathway) in pathways.iter().enumerate() {
+                println!("Pathway {i}: {pathway}");
+            }
+        } else {
+            // Did not time out and only assembly index is desired.
+            println!("{index}");
         }
     }
 

--- a/src/matches.rs
+++ b/src/matches.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 
 /// A node in the DAG storing fragment information; see [`Matches`].
+#[derive(Clone)]
 struct DagNode {
     /// The fragment (i.e., connected molecular subgraph) this node represents.
     fragment: BitSet,
@@ -27,6 +28,7 @@ struct DagNode {
 
 /// Structural information on "matches" in a molecular graph, i.e., pairs of
 /// edge-disjoint, isomorphic subgraphs.
+#[derive(Clone)]
 pub struct Matches {
     /// [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964) perform
     /// match enumeration by constructing a directed acyclic graph (DAG). Each

--- a/src/molecule.rs
+++ b/src/molecule.rs
@@ -271,7 +271,8 @@ impl Molecule {
         &self.graph
     }
 
-    /// Return a pretty-printable representation of this molecule.
+    /// Return a [DOT-formatted](https://graphviz.org/doc/info/lang.html)
+    /// string representation of this molecule's graph structure.
     pub fn info(&self) -> String {
         let dot = Dot::new(&self.graph);
         format!("{dot:?}")

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,12 +1,21 @@
 //! Reconstruct minimum assembly pathways from recursive search information.
 
+use std::fmt;
+
 use bit_set::BitSet;
-use petgraph::{dot::Dot, graph::EdgeIndex};
+use petgraph::{
+    dot::{Config, Dot},
+    graph::{DiGraph, EdgeIndex, NodeIndex},
+};
 
 use crate::{matches::Matches, molecule::Molecule, utils::subgraph_from_edge_mask};
 
 /// Assembly pathway of pairwise joining operations yielding the target graph.
-pub struct Pathway {}
+pub struct Pathway {
+    /// A directed, acyclic graph representation of the assembly pathway; see
+    /// [`Pathway::dag`] for details.
+    dag: DiGraph<String, ()>,
+}
 
 impl Pathway {
     /// Construct the assembly [`Pathway`] of the given molecule corresponding
@@ -48,6 +57,7 @@ impl Pathway {
 
         // Use the bag of pieces to construct all duplicate fragments across
         // matches, starting with the smallest matches and building up.
+        let mut dag = DiGraph::<String, ()>::new();
         for (h1, h2) in &duplicates {
             // If h1 is not already in the bag (as it could be if it is used in
             // multiple matches), construct it by joining pieces in the bag.
@@ -58,7 +68,7 @@ impl Pathway {
                     pieces.extract_if(.., |p| p.is_subset(h1)).collect();
 
                 // Join those pieces iteratively into h1 and add it to the bag.
-                join_pieces(mol, &mut h1_pieces);
+                join_pieces(mol, &mut h1_pieces, &mut dag);
                 pieces.push(h1.clone());
             }
 
@@ -68,15 +78,38 @@ impl Pathway {
 
         // Join whatever fragments are left in the bag until the original
         // molecular graph is recovered.
-        join_pieces(mol, &mut pieces);
+        join_pieces(mol, &mut pieces, &mut dag);
 
-        Self {}
+        Self { dag }
+    }
+
+    /// Get the pathway's directed, acyclic graph representation.
+    ///
+    /// Nodes are fragments (represented as DOT strings) and edges `(u1, v)`
+    /// and `(u2, v)` exist if fragments `u1` and `u2` are joined to produce
+    /// fragment `v`. If `u` is duplicated and joined to itself to produce `v`,
+    /// then the edge `(u, v)` is included twice.
+    pub fn dag(&self) -> &DiGraph<String, ()> {
+        &self.dag
+    }
+}
+
+impl fmt::Display for Pathway {
+    /// Format the assembly pathway DAG as a DOT string whose node labels are
+    /// the DOT strings of their respective fragments.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:?}",
+            Dot::with_config(self.dag(), &[Config::EdgeNoLabel])
+        )
     }
 }
 
 /// Helper function for [`Pathway::new`] that takes as input an edge-disjoint
-/// set of pieces and repeatedly joins all compatible pairs of pieces together.
-fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>) {
+/// set of pieces and repeatedly joins all compatible pairs of pieces together,
+/// tracking these join operations in the given assembly pathway.
+fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<String, ()>) {
     // For each piece, identify the set of nodes it contains.
     let mut piece_nodes = Vec::<BitSet>::new();
     for piece in pieces.iter() {
@@ -97,27 +130,44 @@ fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>) {
         while j < pieces.len() {
             // If pieces i and j share a node, join them into one piece.
             if !piece_nodes[i].is_disjoint(&piece_nodes[j]) {
-                // DEBUG: For now, I am just printing the assembly steps
-                // instead of storing them in a dedicated data structure.
-                print!(
-                    "Joining {:?}",
+                // Get the DOT string representations of pieces i and j.
+                let dot_i = format!(
+                    "{:?}",
                     Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
                 );
-                print!(
-                    "and {:?}",
+                let dot_j = format!(
+                    "{:?}",
                     Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[j]))
                 );
 
+                // Ensure pieces i and j exist as nodes in the pathway DAG.
+                let i_ix = match pathway.raw_nodes().iter().position(|v| v.weight == dot_i) {
+                    Some(v_ix) => NodeIndex::new(v_ix),
+                    _ => pathway.add_node(dot_i),
+                };
+                let j_ix = match pathway.raw_nodes().iter().position(|v| v.weight == dot_j) {
+                    Some(v_ix) => NodeIndex::new(v_ix),
+                    _ => pathway.add_node(dot_j),
+                };
+
+                // Join piece j into piece i and update the nodes contained in
+                // the newly formed piece.
                 let piece_j = pieces.swap_remove(j);
                 pieces[i].union_with(&piece_j);
-
-                println!(
-                    "to construct {:?}",
-                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
-                );
-
                 let piece_nodes_j = piece_nodes.swap_remove(j);
                 piece_nodes[i].union_with(&piece_nodes_j);
+
+                // Get the DOT string representation of the new piece and add
+                // it as a node to the pathway DAG.
+                let dot_joined = format!(
+                    "{:?}",
+                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
+                );
+                let joined_ix = pathway.add_node(dot_joined);
+
+                // Add edges in the pathway DAG representing the join.
+                pathway.add_edge(i_ix, joined_ix, ());
+                pathway.add_edge(j_ix, joined_ix, ());
 
                 joined_piece_i = true;
             } else {

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,11 +1,136 @@
 //! Reconstruct minimum assembly pathways from recursive search information.
 
-use crate::{matches::Matches, molecule::Molecule};
+use bit_set::BitSet;
+use petgraph::{dot::Dot, graph::EdgeIndex};
 
+use crate::{matches::Matches, molecule::Molecule, utils::subgraph_from_edge_mask};
+
+/// Assembly pathway of pairwise joining operations yielding the target graph.
 pub struct Pathway {}
 
 impl Pathway {
+    /// Construct the assembly [`Pathway`] of the given molecule corresponding
+    /// to the given order of removed matches. Efficiently implements the
+    /// duplicate/remnant algorithm described in the Supporting Information
+    /// of [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964).
     pub fn new(mol: &Molecule, matches: &Matches, removal_order: &Vec<usize>) -> Self {
+        // Create a fragment representing the complete molecule.
+        let mut mol_frag = BitSet::new();
+        mol_frag.extend(mol.graph().edge_indices().map(|ix| ix.index()));
+
+        // Get all duplicate fragments from removed matches in reverse order so
+        // that smaller fragments can be used to construct larger ones.
+        let duplicates: Vec<(BitSet, BitSet)> = removal_order
+            .iter()
+            .rev()
+            .map(|&match_ix| {
+                let (h1, h2) = matches.match_fragments(match_ix);
+                (h1.clone(), h2.clone())
+            })
+            .collect();
+
+        // Initialize the assembly pathway's bag of "pieces" as all remnants,
+        // i.e., singleton edges comprising the fragments remaining after all
+        // duplicate fragments are removed. As in [`assembly::fragments`], we
+        // retain each match's first duplicate fragment and remove the second.
+        let mut remnants = mol_frag.clone();
+        for (_, h2) in &duplicates {
+            remnants.difference_with(h2);
+        }
+        let mut pieces: Vec<BitSet> = remnants
+            .iter()
+            .map(|edge_ix| {
+                let mut piece = BitSet::with_capacity(mol.graph().edge_count());
+                piece.insert(edge_ix);
+                piece
+            })
+            .collect();
+
+        // Use the bag of pieces to construct all duplicate fragments across
+        // matches, starting with the smallest matches and building up.
+        for (h1, h2) in &duplicates {
+            // If h1 is not already in the bag (as it could be if it is used in
+            // multiple matches), construct it by joining pieces in the bag.
+            if pieces.iter().find(|&p| p == h1) == None {
+                // Take all pieces that are part of h1; this algorithm ensures
+                // that such pieces are an edge-disjoint partition of h1.
+                let mut h1_pieces: Vec<BitSet> =
+                    pieces.extract_if(.., |p| p.is_subset(h1)).collect();
+
+                // Join those pieces iteratively into h1 and add it to the bag.
+                join_pieces(mol, &mut h1_pieces);
+                pieces.push(h1.clone());
+            }
+
+            // Having constructed/found h1, add its duplicate h2 to the bag.
+            pieces.push(h2.clone());
+        }
+
+        // Join whatever fragments are left in the bag until the original
+        // molecular graph is recovered.
+        join_pieces(mol, &mut pieces);
+
         Self {}
+    }
+}
+
+/// Helper function for [`Pathway::new`] that takes as input an edge-disjoint
+/// set of pieces and repeatedly joins all compatible pairs of pieces together.
+fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>) {
+    // For each piece, identify the set of nodes it contains.
+    let mut piece_nodes = Vec::<BitSet>::new();
+    for piece in pieces.iter() {
+        let mut nodes = BitSet::with_capacity(mol.graph().node_count());
+        for e_ix in piece.iter() {
+            let (end1, end2) = mol.graph().edge_endpoints(EdgeIndex::new(e_ix)).unwrap();
+            nodes.insert(end1.index());
+            nodes.insert(end2.index());
+        }
+        piece_nodes.push(nodes);
+    }
+
+    // Join all compatible pieces together.
+    let mut i = 0;
+    while i < pieces.len() {
+        let mut j = i + 1;
+        let mut joined_piece_i = false;
+        while j < pieces.len() {
+            // If pieces i and j share a node, join them into one piece.
+            if !piece_nodes[i].is_disjoint(&piece_nodes[j]) {
+                // DEBUG: For now, I am just printing the assembly steps
+                // instead of storing them in a dedicated data structure.
+                print!(
+                    "Joining {:?}",
+                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
+                );
+                print!(
+                    "and {:?}",
+                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[j]))
+                );
+
+                let piece_j = pieces.swap_remove(j);
+                pieces[i].union_with(&piece_j);
+
+                println!(
+                    "to construct {:?}",
+                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
+                );
+
+                let piece_nodes_j = piece_nodes.swap_remove(j);
+                piece_nodes[i].union_with(&piece_nodes_j);
+
+                joined_piece_i = true;
+            } else {
+                // Piece j is not compatible with piece i; check the next one.
+                j += 1
+            }
+        }
+
+        // If piece i was not joined to any later pieces, it is a "final"
+        // structure in this assembly (e.g., one connected component in a
+        // disconnected input molecular graph) and can now be set aside.
+        if !joined_piece_i {
+            i += 1
+        }
     }
 }

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -68,7 +68,7 @@ impl Pathway {
         for (h1, h2) in &duplicates {
             // If h1 is not already in the bag (as it could be if it is used in
             // multiple matches), construct it by joining pieces in the bag.
-            if pieces.iter().find(|&p| p == h1).is_none() {
+            if !pieces.iter().any(|p| p == h1) {
                 // Take all pieces that are part of h1; this algorithm ensures
                 // that such pieces are an edge-disjoint partition of h1.
                 let mut h1_pieces: Vec<BitSet> =
@@ -121,7 +121,7 @@ impl fmt::Display for Pathway {
                 self.dag(),
                 &[Config::EdgeNoLabel, Config::NodeNoLabel], // Suppress default labels.
                 &|_, e| format!("label = \"{}\" ", e.weight()),
-                &|_, (_, n_weight)| format!("label = \"{}\" ", n_weight)
+                &|_, (_, n_weight)| format!("label = \"{n_weight}\" ")
             )
         )
     }

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,4 +1,7 @@
 //! Reconstruct minimum assembly pathways from recursive search information.
+//!
+//! See [`Pathway::dag`] for details on the assembly pathway data structure and
+//! [`crate::assembly::index_search`] for examples of pathway reconstruction.
 
 use std::fmt;
 
@@ -107,8 +110,9 @@ impl Pathway {
 }
 
 impl fmt::Display for Pathway {
-    /// Format the assembly pathway DAG as a DOT string whose node and edge
-    /// labels are the BitSets of their respective fragments' bonds.
+    /// Format the assembly pathway DAG as a
+    /// [DOT string](https://graphviz.org/doc/info/lang.html) whose node and
+    /// edge labels are the indices of their respective fragments' bonds.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -181,7 +185,7 @@ fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<B
 }
 
 // Helper function for [`join_pieces`] that finds the pathway node isomorphic
-// to the given piece or adds a new node if one doesn't exist.
+// to the given piece or adds a new node if one doesn't already exist.
 fn find_or_add_dag_node(
     mol: &Molecule,
     piece: &BitSet,

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -29,7 +29,7 @@ impl Pathway {
     /// to the given order of removed matches. Efficiently implements the
     /// duplicate/remnant algorithm described in the Supporting Information
     /// of [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964).
-    pub fn new(mol: &Molecule, matches: &Matches, removal_order: &Vec<usize>) -> Self {
+    pub fn new(mol: &Molecule, matches: &Matches, removal_order: &[usize]) -> Self {
         // Create a fragment representing the complete molecule.
         let mut mol_frag = BitSet::new();
         mol_frag.extend(mol.graph().edge_indices().map(|ix| ix.index()));
@@ -68,7 +68,7 @@ impl Pathway {
         for (h1, h2) in &duplicates {
             // If h1 is not already in the bag (as it could be if it is used in
             // multiple matches), construct it by joining pieces in the bag.
-            if pieces.iter().find(|&p| p == h1) == None {
+            if pieces.iter().find(|&p| p == h1).is_none() {
                 // Take all pieces that are part of h1; this algorithm ensures
                 // that such pieces are an edge-disjoint partition of h1.
                 let mut h1_pieces: Vec<BitSet> =

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -8,13 +8,17 @@ use petgraph::{
     graph::{DiGraph, EdgeIndex, NodeIndex},
 };
 
-use crate::{matches::Matches, molecule::Molecule, utils::subgraph_from_edge_mask};
+use crate::{
+    canonize::{canonize, CanonizeMode},
+    matches::Matches,
+    molecule::Molecule,
+};
 
 /// Assembly pathway of pairwise joining operations yielding the target graph.
 pub struct Pathway {
     /// A directed, acyclic graph representation of the assembly pathway; see
     /// [`Pathway::dag`] for details.
-    dag: DiGraph<String, ()>,
+    dag: DiGraph<BitSet, BitSet>,
 }
 
 impl Pathway {
@@ -57,7 +61,7 @@ impl Pathway {
 
         // Use the bag of pieces to construct all duplicate fragments across
         // matches, starting with the smallest matches and building up.
-        let mut dag = DiGraph::<String, ()>::new();
+        let mut dag = DiGraph::<BitSet, BitSet>::new();
         for (h1, h2) in &duplicates {
             // If h1 is not already in the bag (as it could be if it is used in
             // multiple matches), construct it by joining pieces in the bag.
@@ -83,25 +87,38 @@ impl Pathway {
         Self { dag }
     }
 
-    /// Get the pathway's directed, acyclic graph representation.
+    /// Get the pathway's directed, acyclic (multi)graph representation whose
+    /// nodes represent fragments and edges represent joining operations.
     ///
-    /// Nodes are fragments (represented as DOT strings) and edges `(u1, v)`
-    /// and `(u2, v)` exist if fragments `u1` and `u2` are joined to produce
-    /// fragment `v`. If `u` is duplicated and joined to itself to produce `v`,
-    /// then the edge `(u, v)` is included twice.
-    pub fn dag(&self) -> &DiGraph<String, ()> {
+    /// In detail, each node is labeled by a BitSet indexing the bonds its
+    /// fragment contains. An edge `(u1, v)` labeled `l1` and an edge `(u2, v)`
+    /// labeled `l2` exist iff the fragment BitSet `l1` is isomorphic to `u1`,
+    /// the fragment BitSet `l2` is isomorphic to `u2`, and `l1` and `l2` are
+    /// joined to produce a fragment isomorphic to `v`.
+    ///
+    /// Note that an edge `(u, v)` may be in the DAG multiple times, e.g., if
+    /// two fragments isomorphic to `u` are joined to produce a fragment
+    /// isomorphic to `v`. It may even be in the DAG multiple times *with the
+    /// same label*, e.g., if some fragment isomorphic to `u` is duplicated and
+    /// joined to itself to produce a fragment isomorphic to `v`.
+    pub fn dag(&self) -> &DiGraph<BitSet, BitSet> {
         &self.dag
     }
 }
 
 impl fmt::Display for Pathway {
-    /// Format the assembly pathway DAG as a DOT string whose node labels are
-    /// the DOT strings of their respective fragments.
+    /// Format the assembly pathway DAG as a DOT string whose node and edge
+    /// labels are the BitSets of their respective fragments' bonds.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:?}",
-            Dot::with_config(self.dag(), &[Config::EdgeNoLabel])
+            Dot::with_attr_getters(
+                self.dag(),
+                &[Config::EdgeNoLabel, Config::NodeNoLabel], // Suppress default labels.
+                &|_, e| format!("label = \"{}\" ", e.weight()),
+                &|_, (_, n_weight)| format!("label = \"{}\" ", n_weight)
+            )
         )
     }
 }
@@ -109,7 +126,7 @@ impl fmt::Display for Pathway {
 /// Helper function for [`Pathway::new`] that takes as input an edge-disjoint
 /// set of pieces and repeatedly joins all compatible pairs of pieces together,
 /// tracking these join operations in the given assembly pathway.
-fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<String, ()>) {
+fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<BitSet, BitSet>) {
     // For each piece, identify the set of nodes it contains.
     let mut piece_nodes = Vec::<BitSet>::new();
     for piece in pieces.iter() {
@@ -130,44 +147,22 @@ fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<S
         while j < pieces.len() {
             // If pieces i and j share a node, join them into one piece.
             if !piece_nodes[i].is_disjoint(&piece_nodes[j]) {
-                // Get the DOT string representations of pieces i and j.
-                let dot_i = format!(
-                    "{:?}",
-                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
-                );
-                let dot_j = format!(
-                    "{:?}",
-                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[j]))
-                );
-
-                // Ensure pieces i and j exist as nodes in the pathway DAG.
-                let i_ix = match pathway.raw_nodes().iter().position(|v| v.weight == dot_i) {
-                    Some(v_ix) => NodeIndex::new(v_ix),
-                    _ => pathway.add_node(dot_i),
-                };
-                let j_ix = match pathway.raw_nodes().iter().position(|v| v.weight == dot_j) {
-                    Some(v_ix) => NodeIndex::new(v_ix),
-                    _ => pathway.add_node(dot_j),
-                };
-
                 // Join piece j into piece i and update the nodes contained in
                 // the newly formed piece.
+                let piece_i = pieces[i].clone();
                 let piece_j = pieces.swap_remove(j);
                 pieces[i].union_with(&piece_j);
                 let piece_nodes_j = piece_nodes.swap_remove(j);
                 piece_nodes[i].union_with(&piece_nodes_j);
 
-                // Get the DOT string representation of the new piece and add
-                // it as a node to the pathway DAG.
-                let dot_joined = format!(
-                    "{:?}",
-                    Dot::new(&subgraph_from_edge_mask(mol.graph(), &pieces[i]))
-                );
-                let joined_ix = pathway.add_node(dot_joined);
+                // Ensure pieces i and j exist as nodes in the pathway DAG.
+                let i_ix = find_or_add_dag_node(mol, &piece_i, pathway);
+                let j_ix = find_or_add_dag_node(mol, &piece_j, pathway);
 
-                // Add edges in the pathway DAG representing the join.
-                pathway.add_edge(i_ix, joined_ix, ());
-                pathway.add_edge(j_ix, joined_ix, ());
+                // Add the joined piece and its incoming edges to the DAG.
+                let joined_ix = pathway.add_node(pieces[i].clone());
+                pathway.add_edge(i_ix, joined_ix, piece_i);
+                pathway.add_edge(j_ix, joined_ix, piece_j);
 
                 joined_piece_i = true;
             } else {
@@ -182,5 +177,23 @@ fn join_pieces(mol: &Molecule, pieces: &mut Vec<BitSet>, pathway: &mut DiGraph<S
         if !joined_piece_i {
             i += 1
         }
+    }
+}
+
+// Helper function for [`join_pieces`] that finds the pathway node isomorphic
+// to the given piece or adds a new node if one doesn't exist.
+fn find_or_add_dag_node(
+    mol: &Molecule,
+    piece: &BitSet,
+    pathway: &mut DiGraph<BitSet, BitSet>,
+) -> NodeIndex {
+    let piece_label = canonize(mol, piece, CanonizeMode::TreeNauty);
+    match pathway
+        .raw_nodes()
+        .iter()
+        .position(|v| canonize(mol, &v.weight, CanonizeMode::TreeNauty) == piece_label)
+    {
+        Some(v_ix) => NodeIndex::new(v_ix),
+        _ => pathway.add_node(piece.clone()),
     }
 }

--- a/src/pathway.rs
+++ b/src/pathway.rs
@@ -1,0 +1,11 @@
+//! Reconstruct minimum assembly pathways from recursive search information.
+
+use crate::{matches::Matches, molecule::Molecule};
+
+pub struct Pathway {}
+
+impl Pathway {
+    pub fn new(mol: &Molecule, matches: &Matches, removal_order: &Vec<usize>) -> Self {
+        Self {}
+    }
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -373,6 +373,9 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 /// `"int"`, `"vec-simple"`, `"vec-small-frags"`, `"matchable-edges"`].
 /// The default bounds are [`"int"`, `"matchable-edges"`]. See
 /// [`crate::bounds::Bound`] for details.
+/// - `max_pathways`: An `int` maximum number of minimum assembly pathways to
+/// reconstruct, `0` for all such pathways, or `None` to disable pathway
+/// reconstruction.
 ///
 /// # Python Returns
 ///
@@ -398,14 +401,15 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 ///     parallel_str="none",
 ///     memoize_str="none",
 ///     kernel_str="none",
-///     bound_strs=["int", "matchable-edges"])
+///     bound_strs=["int", "matchable-edges"],
+///     max_pathways=None)
 ///
 /// print(f"Assembly Index:  {index}")            # 6
 /// print(f"Matches:         {num_matches}")      # 466
 /// print(f"States Searched: {states_searched}")  # 491
 /// ```
 #[pyfunction(name = "index_search")]
-#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()]), text_signature = "(mol_block, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"]))")]
+#[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()], max_pathways=None), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"], max_pathways=None)")]
 pub fn _index_search(
     mol_block: &str,
     timeout: Option<u64>,
@@ -414,6 +418,7 @@ pub fn _index_search(
     memoize_str: &str,
     kernel_str: &str,
     bound_strs: Vec<String>,
+    max_pathways: Option<usize>,
 ) -> PyResult<(u32, u32, Option<usize>)> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol = parse_molfile_str(mol_block)?;
@@ -456,6 +461,7 @@ pub fn _index_search(
         memoize_mode,
         kernel_mode,
         &boundlist,
+        max_pathways,
     ))
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -382,9 +382,10 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 ///   `"int"`, `"vec-simple"`, `"vec-small-frags"`, `"matchable-edges"`].
 ///   The default bounds are [`"int"`, `"matchable-edges"`]. See
 ///   [`crate::bounds::Bound`] for details.
-/// - `max_pathways`: An `int` maximum number of minimum assembly pathways to
-///   reconstruct, `0` for all such pathways, or `None` (default) to disable
-///   pathway reconstruction.
+/// - `max_pathways`: An `int` maximum number of minimum assembly pathways to reconstruct, `0` for
+///   all such pathways, or `None` (default) to disable pathway reconstruction. Reconstructing
+///   minimum assembly pathways incurs a 5&ndash;20% runtime overhead; disable for faster assembly
+///   index calculation.
 ///
 /// # Python Returns
 ///

--- a/src/python.rs
+++ b/src/python.rs
@@ -538,6 +538,7 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 /// ```
 #[pyfunction(name = "index_search")]
 #[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()], max_pathways=None), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"], max_pathways=None)")]
+#[allow(clippy::too_many_arguments)]
 pub fn _index_search(
     mol_block: &str,
     timeout: Option<u64>,

--- a/src/python.rs
+++ b/src/python.rs
@@ -59,6 +59,10 @@
 //! # Calculate the molecule's assembly index.
 //! at.index(mol_block)  # 6
 //! ```
+//!
+//! To customize assembly index calculation beyond the default strategy, set a
+//! timeout for long-running calculations, and/or reconstruct minimum assembly
+//! pathways, see [`_index_search`].
 
 use std::str::FromStr;
 
@@ -244,7 +248,8 @@ fn make_boundlist(pybounds: &[PyBound]) -> Vec<OurBound> {
     boundlist
 }
 
-/// Get a pretty-printable string of this molecule's graph representation.
+/// Return a [DOT-formatted](https://graphviz.org/doc/info/lang.html) string
+/// representation of this molecule's graph structure.
 ///
 /// Python version of [`crate::molecule::Molecule::info`].
 ///
@@ -252,7 +257,7 @@ fn make_boundlist(pybounds: &[PyBound]) -> Vec<OurBound> {
 /// - `mol_block`: The contents of a `.mol` file as a `str`.
 ///
 /// # Python Returns
-/// - A pretty-printable `str` detailing the molecule's atoms and bonds.
+/// - A DOT-formatted `str` representing the molecule's atoms and bonds.
 ///
 /// # Python Example
 ///
@@ -318,9 +323,13 @@ pub fn _depth(mol_block: &str) -> PyResult<u32> {
     Ok(depth(&mol))
 }
 
-/// Computes a molecule's assembly index using an efficient default strategy.
+/// Compute a molecule's assembly index using an efficient default strategy.
 ///
 /// Python version of [`index`].
+///
+/// To customize assembly index calculation beyond the default strategy, set a
+/// timeout for long-running calculations, and/or reconstruct minimum assembly
+/// pathways, see [`_index_search`].
 ///
 /// # Python Parameters
 /// - `mol_block`: The contents of a `.mol` file as a `str`.
@@ -349,8 +358,8 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
     Ok(index(&mol))
 }
 
-/// Computes a molecule's assembly index and related information using a
-/// top-down recursive search, parameterized by the specified options.
+/// Compute a molecule's assembly index and related information using a
+/// top-down recursive algorithm, parameterized by the specified options.
 ///
 /// Python version of [`index_search`].
 ///
@@ -358,34 +367,43 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 ///
 /// - `mol_block`: The contents of a `.mol` file as a `str`.
 /// - `timeout`: An `int` duration in milliseconds after which search is
-/// stopped and the best assembly index found so far is returned, or `None` if
-/// search is run until the true assembly index is found.
+///   stopped and the best upper bound on the assembly index found so far is
+///   returned, or `None` (default) if search is run to completion.
 /// - `canonize_str`: A canonization mode from [`"nauty"`, `"faulon"`,
-/// `"tree-nauty"` (default), `"tree-faulon"`]. See [`CanonizeMode`] for
-/// details.
+///   `"tree-nauty"` (default), `"tree-faulon"`]. See [`CanonizeMode`] for
+///   details.
 /// - `parallel_str`: A parallelization mode from [`"none"`, `"depth-one"`
-/// (default), `"always"`]. See [`ParallelMode`] for details.
-/// - `memoize_str`: A memoization mode from [`none`, `frags-index`,
-/// `canon-index` (default)]. See [`MemoizeMode`] for details.
+///   (default), `"always"`]. See [`ParallelMode`] for details.
+/// - `memoize_str`: A memoization mode from [`none`, `canon-index` (default)].
+///   See [`MemoizeMode`] for details.
 /// - `kernel_str`: A kernelization mode from [`"none"` (default), `"once"`,
-/// `"depth-one"`, `"always"`]. See [`KernelMode`] for details.
+///   `"depth-one"`, `"always"`]. See [`KernelMode`] for details.
 /// - `bound_strs`: A list of bounds containing zero or more of [`"log"`,
-/// `"int"`, `"vec-simple"`, `"vec-small-frags"`, `"matchable-edges"`].
-/// The default bounds are [`"int"`, `"matchable-edges"`]. See
-/// [`crate::bounds::Bound`] for details.
+///   `"int"`, `"vec-simple"`, `"vec-small-frags"`, `"matchable-edges"`].
+///   The default bounds are [`"int"`, `"matchable-edges"`]. See
+///   [`crate::bounds::Bound`] for details.
 /// - `max_pathways`: An `int` maximum number of minimum assembly pathways to
-/// reconstruct, `0` for all such pathways, or `None` to disable pathway
-/// reconstruction.
+///   reconstruct, `0` for all such pathways, or `None` (default) to disable
+///   pathway reconstruction.
 ///
 /// # Python Returns
 ///
-/// A 3-tuple containing:
+/// A 4-tuple containing:
 /// - The molecule's `int` assembly index (or an upper bound if timed out).
 /// - The molecule's `int` number of edge-disjoint isomorphic subgraph pairs.
-/// - The `int` number of assembly states searched, or `None` if timed out.
+/// - The `int` number of assembly states searched if search completes, or
+///   `None` otherwise (i.e., if search timed out).
+/// - A list of [DOT-formatted](https://graphviz.org/doc/info/lang.html) `str`
+///   representations of the molecule's minimum assembly pathways. This list is
+///   nonempty if and only if search did not time out and `max_pathways` is not
+///   `None`.
 ///
-/// # Python Example
+/// # Python Examples
 ///
+/// ## Customizing Assembly Index Search Options
+///
+/// The two examples below show different customizations of the assembly index
+/// search options, enabling/disabling parallelism, memoization, and bounding.
 /// ```custom,{class=language-python}
 /// import assembly_theory as at
 ///
@@ -393,20 +411,130 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 /// with open('data/checks/anthracene.mol') as f:
 ///     mol_block = f.read()
 ///
-/// # Calculate the molecule's assembly index using the specified options.
-/// (index, num_matches, states_searched, _) = at.index_search(
+/// # Calculate the molecule's assembly index without any search optimizations
+/// # like parallelism, memoization, kernelization, or bounding.
+/// (slow_index, num_matches, states_searched, _) = at.index_search(
 ///     mol_block,
 ///     timeout=None,
 ///     canonize_str="tree-nauty",
-///     parallel_str="none",
-///     memoize_str="none",
-///     kernel_str="none",
-///     bound_strs=["int", "matchable-edges"],
+///     parallel_str="none",        # Disable parallelism.
+///     memoize_str="none",         # Disable memoization.
+///     kernel_str="none",          # Disable kernelization.
+///     bound_strs=[],              # Disable bounding.
 ///     max_pathways=None)
-///
-/// print(f"Assembly Index:  {index}")            # 6
+/// print(f"Assembly Index:  {slow_index}")       # 6
 /// print(f"Matches:         {num_matches}")      # 466
-/// print(f"States Searched: {states_searched}")  # 491
+/// print(f"States Searched: {states_searched}")  # 133814
+///
+/// # Repeat the calculation with parallelism, memoization, and some bounds.
+/// (fast_index, num_matches, states_searched, _) = at.index_search(
+///     mol_block,
+///     timeout=None,
+///     canonize_str="tree-nauty",
+///     parallel_str="depth-one",   # Enable parallelism.
+///     memoize_str="canon-index",  # Enable memoization.
+///     kernel_str="none",
+///     bound_strs=["log", "int"],  # Enable some bounds.
+///     max_pathways=None)
+/// print(f"Assembly Index:  {fast_index}")       # 6, unchanged
+/// print(f"Matches:         {num_matches}")      # 466, unchanged
+/// print(f"States Searched: {states_searched}")  # 1607, e.g., but parallelism makes this nondeterministic
+/// ```
+///
+/// ## Setting a Timeout for Long Calculations
+///
+/// Assembly index calculation can be slow on large molecules, even with search
+/// optimizations enabled. If `timeout` is set, two outcomes are possible:
+/// 1. Search completes before the timeout and everything behaves as usual.
+/// 2. The timeout is reached before search completes, search is interrupted,
+///    and the best upper bound on the assembly index found so far is returned.
+///    The number of states searched and assembly pathways are not returned.
+/// ```custom,{class=language-python}
+/// # Limit search to 10 s, which is plenty for search to complete as usual,
+/// # even with some search optimizations disabled.
+/// (true_index, num_matches, states_searched, pathways) = at.index_search(
+///     mol_block,
+///     timeout=10000,              # Set a 10 s timeout.
+///     canonize_str="tree-nauty",
+///     parallel_str="none",        # Disable parallelism.
+///     memoize_str="none",         # Disable memoization.
+///     kernel_str="none",          # Disable kernelization.
+///     bound_strs=["log", "int"],  # Enable some bounds.
+///     max_pathways=1)             # Reconstruct one pathway.
+/// print(f"Assembly Index:         {true_index}")       # 6
+/// print(f"Matches:                {num_matches}")      # 466
+/// print(f"States Searched:        {states_searched}")  # 2454
+/// print(f"Pathways Reconstructed: {len(pathways)}")    # 1
+///
+/// # Limit search to 1 ms, which will time out without more optimizations.
+/// (index_bound, num_matches, states_searched, pathways) = at.index_search(
+///     mol_block,
+///     timeout=1,                  # Set a 1 ms timeout.
+///     canonize_str="tree-nauty",
+///     parallel_str="none",        # Disable parallelism.
+///     memoize_str="none",         # Disable memoization.
+///     kernel_str="none",          # Disable kernelization.
+///     bound_strs=["log", "int"],  # Enable some bounds.
+///     max_pathways=1)             # Reconstruct one pathway.
+/// print(f"Assembly Index:         {index_bound}")      # >= 6
+/// print(f"Matches:                {num_matches}")      # 466, unaffected
+/// print(f"States Searched:        {states_searched}")  # None, not computed on timeout
+/// print(f"Pathways Reconstructed: {len(pathways)}")    # 0, not computed on timeout
+/// ```
+///
+/// ## Reconstructing Minimum Assembly Pathways
+///
+/// An assembly pathway records the fragment join operations producing the
+/// target molecule. Set `max_pathways` to `0` to reconstruct all minimum
+/// assembly pathways discovered by the search process, `n` for at most the
+/// first `n` such pathways, or `None` to disable pathway reconstruction.
+/// See [`crate::pathway::Pathway::dag`] for details on the pathway data
+/// structure.
+///
+/// Note that the definition of `max_pathway = 0`'s behavior is very carefully
+/// worded: it finds all minimum assembly pathways *discovered by the search
+/// process*. This is not to be taken as *all possible minimum assembly
+/// pathways*. When search optimizations like parallelism, memoization, and
+/// bounding are used, search prunes pathways that cannot yield a better
+/// assembly index. This may include pathways that yield an *equal* (i.e., also
+/// minimum) assembly index. Once pruned, these pathways will not survive to
+/// pathway reconstruction.
+/// ```custom,{class=language-python}
+/// # Reconstruct a minimum assembly pathway discovered during search.
+/// (_, _, _, pathways) = at.index_search(
+///     mol_block,
+///     timeout=None,
+///     canonize_str="tree-nauty",
+///     parallel_str="none",        # Disable parallelism for determinism.
+///     memoize_str="canon-index",
+///     kernel_str="none",
+///     bound_strs=["log", "int"],
+///     max_pathways=1)             # Reconstruct one pathway.
+/// print(pathways[0])
+///
+/// # digraph {
+/// #     0 [ label = "{14}" ]
+/// #     1 [ label = "{15}" ]
+/// #     2 [ label = "{14, 15}" ]
+/// #     3 [ label = "{7, 14, 15}" ]
+/// #     4 [ label = "{6, 7, 14, 15}" ]
+/// #     5 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+/// #     6 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+/// #     7 [ label = "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}" ]
+/// #     0 -> 2 [ label = "{14}" ]
+/// #     1 -> 2 [ label = "{15}" ]
+/// #     0 -> 3 [ label = "{7}" ]
+/// #     2 -> 3 [ label = "{14, 15}" ]
+/// #     1 -> 4 [ label = "{6}" ]
+/// #     3 -> 4 [ label = "{7, 14, 15}" ]
+/// #     4 -> 5 [ label = "{6, 7, 14, 15}" ]
+/// #     3 -> 5 [ label = "{3, 4, 5}" ]
+/// #     2 -> 6 [ label = "{2, 13}" ]
+/// #     5 -> 6 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
+/// #     6 -> 7 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
+/// #     5 -> 7 [ label = "{0, 1, 8, 9, 10, 11, 12}" ]
+/// # }
+/// #
 /// ```
 #[pyfunction(name = "index_search")]
 #[pyo3(signature = (mol_block, timeout=None, canonize_str="tree-nauty", parallel_str="depth-one", memoize_str="canon-index", kernel_str="none", bound_strs=vec!["int".to_string(), "matchable-edges".to_string()], max_pathways=None), text_signature = "(mol_block, timeout=None, canonize_str=\"tree-nauty\", parallel_str=\"depth-one\", memoize_str=\"canon-index\", kernel_str=\"none\", bound_strs=[\"int\", \"matchable-edges\"], max_pathways=None)")]

--- a/src/python.rs
+++ b/src/python.rs
@@ -394,7 +394,7 @@ pub fn _index(mol_block: &str) -> PyResult<u32> {
 ///     mol_block = f.read()
 ///
 /// # Calculate the molecule's assembly index using the specified options.
-/// (index, num_matches, states_searched) = at.index_search(
+/// (index, num_matches, states_searched, _) = at.index_search(
 ///     mol_block,
 ///     timeout=None,
 ///     canonize_str="tree-nauty",
@@ -419,7 +419,7 @@ pub fn _index_search(
     kernel_str: &str,
     bound_strs: Vec<String>,
     max_pathways: Option<usize>,
-) -> PyResult<(u32, u32, Option<usize>)> {
+) -> PyResult<(u32, u32, Option<usize>, Vec<String>)> {
     // Parse the .mol file contents as a molecule::Molecule.
     let mol = parse_molfile_str(mol_block)?;
 
@@ -453,8 +453,7 @@ pub fn _index_search(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    // TODO: Update to also return pathways in a sensible way.
-    let (index, num_matches, states_searched, _) = index_search(
+    let (index, num_matches, states_searched, pathways) = index_search(
         &mol,
         timeout,
         canonize_mode,
@@ -464,7 +463,14 @@ pub fn _index_search(
         &boundlist,
         max_pathways,
     );
-    Ok((index, num_matches, states_searched))
+
+    // Format assembly pathways as DOT strings.
+    let mut pathways_dot = Vec::<String>::new();
+    for pathway in pathways {
+        pathways_dot.push(format!("{pathway}"));
+    }
+
+    Ok((index, num_matches, states_searched, pathways_dot))
 }
 
 /// A Python wrapper for the assembly_theory Rust crate.

--- a/src/python.rs
+++ b/src/python.rs
@@ -453,7 +453,8 @@ pub fn _index_search(
     let boundlist = make_boundlist(&pybounds);
 
     // Compute assembly index.
-    Ok(index_search(
+    // TODO: Update to also return pathways in a sensible way.
+    let (index, num_matches, states_searched, _) = index_search(
         &mol,
         timeout,
         canonize_mode,
@@ -462,7 +463,8 @@ pub fn _index_search(
         kernel_mode,
         &boundlist,
         max_pathways,
-    ))
+    );
+    Ok((index, num_matches, states_searched))
 }
 
 /// A Python wrapper for the assembly_theory Rust crate.

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -71,7 +71,7 @@ fn test_reference_dataset(
         .expect(&format!("Failed to parse {name:?}"));
 
         // Calculate the molecule's assembly index.
-        let (index, _, _) = index_search(
+        let (index, _, _, _) = index_search(
             &mol,
             None,
             canonize_mode,

--- a/tests/reference_datasets.rs
+++ b/tests/reference_datasets.rs
@@ -79,6 +79,7 @@ fn test_reference_dataset(
             memoize_mode,
             kernel_mode,
             bounds,
+            None,
         );
 
         // Compare calculated assembly index to ground truth.


### PR DESCRIPTION
Resolves #22, enabling minimum assembly pathway extraction. Subsumes #146 and #147.

There's a lot to talk about here, but the TL;DR is this: we now finally support assembly pathway reconstruction, we do so in a reasonably efficient way (5&ndash;20% performance overhead to search when reconstructing pathways, negligible performance differences if pathway reconstruction is disabled), and our pathway data format is more informative and interoperable with downstream tools than what's out there right now.

## Specifying Assembly Pathway Reconstruction

There are several interface-level changes:
- the CLI now has a `--pathways` option
- the Rust `index_search` function now takes a mandatory `max_pathways: Option<usize>` parameter
- the Python `index_search` function now takes a `max_pathways: int/None` parameter (default `None`)

All of these basically work the same way:
- If `--pathways` is not set (CLI) or `max_pathways = None` (Rust/Python), assembly pathway reconstruction is disabled and things mostly work as before.
- If `--pathways n` (CLI) or `max_pathways = n` (Rust/Python) for some integer `n > 0`, we return at most `n` minimum assembly pathways discovered during assembly index search.
- If `--pathways 0` (CLI) or `max_pathways = 0` (Rust/Python), we return *all* minimum assembly pathways discovered during assembly index search.

Note that the last of these settings does not necessarily return *all possible* minimum assembly pathways. When search optimizations like bounding and memoization are enabled, we prune any search states that cannot yield a better bound on the assembly index. This includes assembly states that may attain *equally good* assembly index bounds, and in particular, those that would attain the true assembly index after one such state is already found. These states may also potentially yield minimum assembly pathways, but they are pruned for search efficiency.

## Assembly Pathway Representation

Assembly pathways are represented as directed, acyclic multigraphs (DAGs) whose nodes are molecular graph fragments and whose edges represent joining operations. Our data structure is similar to what you would need for the [Croninlab visualization](https://molecular-assembly.com/query-v5/), but with a few additional improvements. Formally:
- Each DAG node represents a *canonical fragment* (i.e., a connected subgraph) of the target molecular graph. These fragments are "canonical" in the sense that they are deduplicated by isomorphism. For example, if an assembly pathway joins two `CC` single bonds together to form a `CCC` and then joins another single `CC` bond to that structure to form a `CCCC` chain, the `CC` fragment will only be represented once as a node in the DAG.
- The DAG contains directed edges $`u_1 \to v`$ and $`u_2 \to v`$ if and only if some fragment $`f_1`$ isomorphic to $`u_1`$ and some fragment $`f_2`$ isomorphic to $`u_2`$ are joined to produce a fragment $`f_3`$ isomorphic to $`v`$ in the assembly pathway. This means that an edge $`u \to v`$ may appear in the DAG multiple times (hence it is a *multi*graph) if, e.g., two isomorphic fragments are joined to each other.
- Digging deeper, each DAG node and edge has a *label* that specifies exactly which bonds from the target molecular graph its fragment contains. For DAG nodes, this label specifies the bonds of the first real instance of that node's canonical fragment. For DAG edges $`u_1 \to v`$ and $`u_2 \to v`$ representing the joining of fragment $`f_1`$ isomorphic to $`u_1`$ and fragment $`f_2`$ isomorphic to $`u_2`$, the edges are labeled with the bonds of $`f_1`$ and $`f_2`$, respectively. This means that the pathway not only represents which canonical fragments are joined to produce other canonical fragments, but which *specific instances* of those canonical fragments were used in joining operations.

Pathways are returned as follows:

- The CLI prints the target molecular graph and any reconstructed assembly pathways as [DOT-formatted](https://graphviz.org/doc/info/lang.html) strings. For the pathway graphs, node and edge labels are sets of bond indices corresponding to the bonds in the target molecular graph.
<details>
<summary>Example Output for Anthracene</summary>

```
> ./target/release/assembly-theory data/checks/anthracene.mol --parallel none --pathways 0
Assembly Index:  6
Matches:         466
States Searched: 491
Pathways Found:  2

Molecule Graph: graph {
    0 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    1 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    2 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    3 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    4 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    5 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    6 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    7 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    8 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    9 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    10 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    11 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    12 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    13 [ label = "Atom { element: Carbon, capacity: 0 }" ]
    8 -- 7 [ label = "Double" ]
    7 -- 4 [ label = "Single" ]
    4 -- 3 [ label = "Double" ]
    3 -- 0 [ label = "Single" ]
    0 -- 1 [ label = "Double" ]
    1 -- 2 [ label = "Single" ]
    2 -- 5 [ label = "Double" ]
    8 -- 9 [ label = "Single" ]
    9 -- 10 [ label = "Single" ]
    10 -- 11 [ label = "Double" ]
    11 -- 12 [ label = "Single" ]
    12 -- 13 [ label = "Double" ]
    13 -- 8 [ label = "Single" ]
    4 -- 5 [ label = "Single" ]
    5 -- 6 [ label = "Single" ]
    6 -- 9 [ label = "Double" ]
}

Pathway 0: digraph {
    0 [ label = "{14}" ]
    1 [ label = "{15}" ]
    2 [ label = "{14, 15}" ]
    3 [ label = "{7, 14, 15}" ]
    4 [ label = "{6, 7, 14, 15}" ]
    5 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
    6 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
    7 [ label = "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}" ]
    0 -> 2 [ label = "{14}" ]
    1 -> 2 [ label = "{15}" ]
    0 -> 3 [ label = "{7}" ]
    2 -> 3 [ label = "{14, 15}" ]
    1 -> 4 [ label = "{6}" ]
    3 -> 4 [ label = "{7, 14, 15}" ]
    4 -> 5 [ label = "{6, 7, 14, 15}" ]
    3 -> 5 [ label = "{3, 4, 5}" ]
    2 -> 6 [ label = "{2, 13}" ]
    5 -> 6 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
    6 -> 7 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
    5 -> 7 [ label = "{0, 1, 8, 9, 10, 11, 12}" ]
}

Pathway 1: digraph {
    0 [ label = "{7}" ]
    1 [ label = "{15}" ]
    2 [ label = "{7, 15}" ]
    3 [ label = "{7, 14, 15}" ]
    4 [ label = "{6, 7, 14, 15}" ]
    5 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
    6 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
    7 [ label = "{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}" ]
    0 -> 2 [ label = "{7}" ]
    1 -> 2 [ label = "{15}" ]
    0 -> 3 [ label = "{14}" ]
    2 -> 3 [ label = "{7, 15}" ]
    1 -> 4 [ label = "{6}" ]
    3 -> 4 [ label = "{7, 14, 15}" ]
    4 -> 5 [ label = "{6, 7, 14, 15}" ]
    3 -> 5 [ label = "{3, 4, 5}" ]
    2 -> 6 [ label = "{2, 13}" ]
    5 -> 6 [ label = "{3, 4, 5, 6, 7, 14, 15}" ]
    6 -> 7 [ label = "{2, 3, 4, 5, 6, 7, 13, 14, 15}" ]
    5 -> 7 [ label = "{0, 1, 8, 9, 10, 11, 12}" ]
}
```
</details>

- The Rust `index_search` function returns a `Vec<Pathway>`, where the `Pathway` struct represents a single assembly pathway as a [`petgraph::Digraph`](https://docs.rs/petgraph/latest/petgraph/graph/type.DiGraph.html) whose nodes/edges are labeled by [`bit_set::BitSet`](https://docs.rs/bit-set/latest/bit_set/struct.BitSet.html)s indexing their fragments' bonds, following the specifications above.
- The Python `index_search` function returns a `list[str]` containing the [DOT-formatted](https://graphviz.org/doc/info/lang.html) string representations of all reconstructed assembly pathways, appearing exactly as they do in the CLI output.

This data format is particularly nice for the Python interface, which can load these DOT strings up in [graphviz](https://graphviz.org/), parse the node and edge labels as sets using Python's [`ast.literal_eval`](https://docs.python.org/3/library/ast.html#ast.literal_eval), and then throw those sets into RDKit's [`PathToSubmol`](https://www.rdkit.org/docs/source/rdkit.Chem.rdmolops.html#rdkit.Chem.rdmolops.PathToSubmol) to get the actual molecular fragments used in the assembly pathway and visualize them. This PR **does not** implement this functionality (it's big enough as is), but sets up all the necessary data structures.

## Performance Impact

When assembly pathway reconstruction is disabled, search performance is not impacted:

<details>

<summary>Benchmark 06e6582 (this PR) vs. a992612 (current main) as a baseline</summary>

```
bench_bounds/gdb13_1201/no-bounds
                        time:   [65.494 ms 65.956 ms 66.446 ms]
                        change: [+1.4671% +2.4459% +3.5088%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_bounds/gdb13_1201/log
                        time:   [63.690 ms 64.226 ms 64.755 ms]
                        change: [−0.7080% +0.3538% +1.3847%] (p = 0.52 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int
                        time:   [60.384 ms 60.987 ms 61.538 ms]
                        change: [−0.2027% +1.1940% +2.4425%] (p = 0.08 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int-vec
                        time:   [56.909 ms 57.341 ms 57.788 ms]
                        change: [−0.3523% +0.9907% +2.4137%] (p = 0.17 > 0.05)
                        No change in performance detected.
bench_bounds/gdb13_1201/int-matchable
                        time:   [61.348 ms 61.755 ms 62.203 ms]
                        change: [+0.8296% +1.9401% +3.0818%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_bounds/gdb17_200/no-bounds
                        time:   [208.20 ms 210.56 ms 212.99 ms]
                        change: [−0.9079% +0.4494% +1.8667%] (p = 0.54 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/log
                        time:   [148.47 ms 149.23 ms 149.93 ms]
                        change: [−0.9271% −0.2737% +0.4107%] (p = 0.45 > 0.05)
                        No change in performance detected.
bench_bounds/gdb17_200/int
                        time:   [51.486 ms 51.710 ms 51.955 ms]
                        change: [+0.5067% +1.1016% +1.7279%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_bounds/gdb17_200/int-vec
                        time:   [50.365 ms 50.619 ms 50.895 ms]
                        change: [+1.2835% +1.9808% +2.7218%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_bounds/gdb17_200/int-matchable
                        time:   [40.506 ms 40.661 ms 40.821 ms]
                        change: [+1.2662% +1.9492% +2.6835%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_bounds/checks/no-bounds
                        time:   [164.24 ms 167.38 ms 170.49 ms]
                        change: [−0.5238% +2.1960% +4.9069%] (p = 0.11 > 0.05)
                        No change in performance detected.
bench_bounds/checks/log time:   [94.569 ms 95.478 ms 96.432 ms]
                        change: [−1.9663% −0.6575% +0.6738%] (p = 0.35 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int time:   [10.945 ms 11.002 ms 11.060 ms]
                        change: [−0.3730% +0.5608% +1.6315%] (p = 0.32 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int-vec
                        time:   [7.8191 ms 7.8653 ms 7.9188 ms]
                        change: [−0.5047% +0.4176% +1.2699%] (p = 0.39 > 0.05)
                        No change in performance detected.
bench_bounds/checks/int-matchable
                        time:   [6.2968 ms 6.3299 ms 6.3710 ms]
                        change: [−0.5332% +0.4232% +1.4514%] (p = 0.43 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/no-bounds
                        time:   [1.8370 s 1.8948 s 1.9590 s]
                        change: [−2.6141% +1.1449% +5.6358%] (p = 0.58 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/log
                        time:   [1.3173 s 1.3410 s 1.3647 s]
                        change: [−0.1705% +2.2820% +4.7587%] (p = 0.09 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int
                        time:   [129.00 ms 130.41 ms 131.73 ms]
                        change: [−1.1622% +0.3864% +1.9602%] (p = 0.62 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int-vec
                        time:   [114.17 ms 115.79 ms 117.40 ms]
                        change: [−1.7570% −0.0124% +1.7974%] (p = 0.98 > 0.05)
                        No change in performance detected.
bench_bounds/coconut_55/int-matchable
                        time:   [43.933 ms 44.095 ms 44.265 ms]
                        change: [−0.2354% +0.3520% +0.9733%] (p = 0.28 > 0.05)
                        No change in performance detected.

bench_memoize/gdb13_1201/no-memoize
                        time:   [46.247 ms 46.503 ms 46.768 ms]
                        change: [+1.8958% +2.7615% +3.5646%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_memoize/gdb13_1201/nauty-index
                        time:   [63.671 ms 64.097 ms 64.520 ms]
                        change: [+0.8332% +1.9288% +3.0107%] (p = 0.00 < 0.05)
                        Change within noise threshold.
bench_memoize/gdb13_1201/tree-nauty-index
                        time:   [60.756 ms 61.208 ms 61.666 ms]
                        change: [+1.2603% +2.3707% +3.3642%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_memoize/gdb17_200/no-memoize
                        time:   [25.407 ms 25.547 ms 25.760 ms]
                        change: [−1.9346% +2.7001% +7.6541%] (p = 0.29 > 0.05)
                        No change in performance detected.
bench_memoize/gdb17_200/nauty-index
                        time:   [43.316 ms 43.473 ms 43.608 ms]
                        change: [+1.0217% +1.7233% +2.3440%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_memoize/gdb17_200/tree-nauty-index
                        time:   [40.503 ms 40.733 ms 40.941 ms]
                        change: [+1.5477% +2.3846% +3.2019%] (p = 0.00 < 0.05)
                        Performance has regressed.
bench_memoize/checks/no-memoize
                        time:   [4.2806 ms 4.3040 ms 4.3341 ms]
                        change: [−1.0161% −0.1236% +0.6600%] (p = 0.79 > 0.05)
                        No change in performance detected.
bench_memoize/checks/nauty-index
                        time:   [7.1944 ms 7.2393 ms 7.2811 ms]
                        change: [−0.2995% +0.4269% +1.1962%] (p = 0.28 > 0.05)
                        No change in performance detected.
bench_memoize/checks/tree-nauty-index
                        time:   [6.2994 ms 6.3144 ms 6.3357 ms]
                        change: [−0.8565% +0.1030% +1.0101%] (p = 0.83 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/no-memoize
                        time:   [34.316 ms 34.437 ms 34.567 ms]
                        change: [−1.7318% −0.0664% +1.4859%] (p = 0.94 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/nauty-index
                        time:   [48.713 ms 48.955 ms 49.221 ms]
                        change: [−0.2698% +0.4273% +1.0910%] (p = 0.24 > 0.05)
                        No change in performance detected.
bench_memoize/coconut_55/tree-nauty-index
                        time:   [44.061 ms 44.199 ms 44.339 ms]
                        change: [+0.6638% +1.0976% +1.5606%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```
</details>

A new benchmark, `bench_removal_orders`, compares search performance across three scenarios: (1) assembly pathway reconstruction disabled, (2) reconstructing *one* minimum assembly pathway discovered during search, and (3) reconstructing *all* minimum assembly pathways discovered during search. The raw data is below, but search incurs a 5&ndash;20% overhead when collecting match removal orders for later assembly pathway reconstruction. The overhead is smaller when fewer match removal orders are collected (e.g., for `coconut_55`, the overhead is 11.84% for one match removal order but 15.94% for all).

<details>

<summary>Benchmark 06e6582 (this PR) on search with assembly pathway reconstruction enabled</summary>

```
bench_removal_orders/gdb13_1201/none
                        time:   [60.436 ms 60.894 ms 61.388 ms]
bench_removal_orders/gdb13_1201/one
                        time:   [63.645 ms 64.122 ms 64.705 ms]
bench_removal_orders/gdb13_1201/all
                        time:   [63.722 ms 64.253 ms 64.818 ms]
bench_removal_orders/gdb17_200/none
                        time:   [40.628 ms 40.794 ms 40.977 ms]
bench_removal_orders/gdb17_200/one
                        time:   [47.618 ms 47.897 ms 48.192 ms]
bench_removal_orders/gdb17_200/all
                        time:   [48.229 ms 48.536 ms 48.858 ms]
bench_removal_orders/checks/none
                        time:   [6.3210 ms 6.3424 ms 6.3767 ms]
bench_removal_orders/checks/one
                        time:   [7.1797 ms 7.2185 ms 7.2626 ms]
bench_removal_orders/checks/all
                        time:   [7.4138 ms 7.4457 ms 7.4872 ms]
bench_removal_orders/coconut_55/none
                        time:   [43.985 ms 44.134 ms 44.286 ms]
bench_removal_orders/coconut_55/one
                        time:   [49.143 ms 49.359 ms 49.580 ms]
bench_removal_orders/coconut_55/all
                        time:   [51.036 ms 51.170 ms 51.310 ms]
```
</details>

## Algorithm Details

Tracking match removal orders during search was something we were already doing; #149 and #150 handled the necessary setup to be used for assembly pathway reconstruction. Our reconstruction algorithm is an efficient implementation of the duplicate/remnant algorithm described in the Supporting Information of [Seet et al. (2025)](https://doi.org/10.1021/acs.jcim.5c01964).